### PR TITLE
chore(release): prepare v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,18 +17,23 @@ preserved at the bottom of this file for reference.
 
 ---
 
-## [Unreleased]
+## [0.2.3] &mdash; 2026-06-09
 
-Analyzer-only release in `NexusLabs.Framework.Analyzers` (seven new rules,
-NLF0013 through NLF0019), with the dog-fooded breaking changes the new
-strictness surfaced in `NexusLabs.Framework`, `NexusLabs.Data.Sql`, and
-`NexusLabs.Data.Sql.MySql`. `NexusLabs.Xunit.Assertions` gains per-
+Release covering seven new analyzer rules (NLF0013 through NLF0019) in
+`NexusLabs.Framework.Analyzers`, a new `AsyncGate` async manual-reset
+primitive in `NexusLabs.Framework`, and the dog-fooded breaking changes
+the new analyzer strictness surfaced in `NexusLabs.Framework`,
+`NexusLabs.Data.Sql`, and `NexusLabs.Data.Sql.MySql`. `NexusLabs.Xunit.Assertions` gains per-
 method `#pragma` suppressions on its `TriedEx`/`TriedNullEx`-aware
 assertion helpers — no behavioural change there, just an explicit
 opt-out from the new NLF0015 rule that the helpers structurally
 contradict (their job is to consume Try-results, not produce them).
 
 ### NexusLabs.Framework
+
+Added &mdash; async coordination primitive:
+
+- **`AsyncGate`** (`NexusLabs.Framework.Threading`) &mdash; a sealed, `IDisposable` async manual-reset gate: an awaitable signal callers park on via `WaitAsync(CancellationToken)` until `Set()` opens it (releasing every current and future waiter until `Reset()`). Mirrors `ManualResetEventSlim` (`Set`/`Reset`/`IsSet`) but exposes an awaitable wait, so no thread-pool thread is held while parked; built on a `TaskCompletionSource` created with `RunContinuationsAsynchronously` so a waiter's continuation never runs inline on the thread that calls `Set()`. `Set()` is the release; `Dispose()` is scope-exit teardown that **cancels** any still-parked waiter (they observe `OperationCanceledException`, never a normal completion) &mdash; the inverse of a resource lease such as `AsyncSemaphoreLease`, where disposal is the release.
 
 Changed (**BREAKING**) &mdash; `SemaphoreSlim` extension rename:
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
       of the entire monorepo; the release workflow packs + pushes every package
       at the same version.
     -->
-    <Version>0.2.2</Version>
+    <Version>0.2.3</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">


### PR DESCRIPTION
## Release prep: v0.2.3

Bumps the lockstep `<Version>` 0.2.2 -> **0.2.3** and finalizes the CHANGELOG `[Unreleased]` section as `[0.2.3] — 2026-06-09`. No code changes.

### What ships in 0.2.3
Everything merged since `v0.2.2`:
- **Analyzers:** seven new rules, NLF0013–**NLF0019** (NLF0019 = empty read-only collection allocations — the package''s first `Performance` rule).
- **Framework:** new `AsyncGate` async manual-reset primitive.
- **Breaking (pre-1.0):** `SemaphoreSlim.TryAcquireAsync` -> `AcquireOrNullAsync`; `CancellationToken` defaults removed on `Process` extensions; `IDbConnectionFactory` / `IAsyncDbDataReader` signature changes. Per pre-1.0 versioning these ship as a **patch** increment by design.

### CHANGELOG accuracy fixes (please review)
The `[Unreleased]` section was drafted as an "analyzer-only release" before `AsyncGate` landed, and `AsyncGate` had no entry. This PR:
- Corrects the intro to mention the `AsyncGate` primitive.
- Adds an `AsyncGate` entry under `### NexusLabs.Framework` — **written from the source, so please sanity-check it** since I did not author that feature.

### Verification (Release config, mirrors `release.yml`)
- Build: **0 warnings, 0 errors** across the solution.
- Tests: **total 664, succeeded 663, skipped 1, failed 0**. The 1 skip is the pre-existing known-flaky `GenericEventExtensions` unordered + stopOnFirstError test, tracked separately.

### Next step (NOT done here)
After this merges, the release is triggered by tagging the merge commit and pushing the tag:

```
git tag v0.2.3 && git push origin v0.2.3
```

That fires `release.yml` -> packs at `<Version>` -> publishes every package to nuget.org via OIDC trusted publishing. I will not push that tag without your explicit go-ahead (it is an irreversible publish).
