### PR TITLE
feat: self-deleting temporary file/directory primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ preserved at the bottom of this file for reference.
 
 ---
 
+## [Unreleased]
+
+### NexusLabs.Framework
+
+Added &mdash; temporary file and directory primitives (`NexusLabs.Framework.IO`):
+
+- `ITemporaryDirectory` / `ITemporaryFile` &mdash; `IDisposable` + `IAsyncDisposable`
+  handles that delete themselves (and, for directories, their contents) on disposal.
+  Use them with `using` / `await using`, mirroring the `AsyncSemaphoreLease` pattern.
+- `ITemporaryDirectoryFactory` / `ITemporaryFileFactory` (plus the default
+  `TemporaryDirectoryFactory` / `TemporaryFileFactory`) &mdash; the mockable creation seam so
+  consumer code can be unit tested without touching the real file system.
+- `TemporaryDirectoryOptions` / `TemporaryFileOptions` &mdash; configure the root location, name
+  prefix, file extension / pre-creation, cleanup-failure handling (`OnCleanupError`), and an
+  optional `DeleteExecutor` resilience policy, all at creation time.
+- `ResilientDeleteExecutor` &mdash; a delegate whose signature matches the common
+  `Execute(operation, cancellationToken)` shape of resilience pipelines, so a caller drops their
+  retry/backoff policy in as a method group (`DeleteExecutor = myResiliencePolicy.ExecuteAsync`)
+  with no adapter and **no third-party dependency in the package**. Deletion clears read-only
+  attributes, is reparse-point-safe, treats an already-deleted resource as success, never throws
+  from `Dispose`, and routes the final failure to `OnCleanupError` (or the factory's logger) rather
+  than silently giving up.
+
+---
+
 ## [0.2.4] &mdash; 2026-06-17
 
 Release covering four new analyzer rules in `NexusLabs.Framework.Analyzers`

--- a/src/NexusLabs.Framework/IO/ITemporaryDirectory.cs
+++ b/src/NexusLabs.Framework/IO/ITemporaryDirectory.cs
@@ -6,7 +6,7 @@ namespace NexusLabs.Framework.IO;
 /// <c>using</c> / <c>await using</c>:
 /// <code>
 /// await using var dir = factory.Create();
-/// await File.WriteAllTextAsync(dir.Combine("data.txt"), "...", cancellationToken);
+/// await File.WriteAllTextAsync(Path.Combine(dir.Path, "data.txt"), "...", cancellationToken);
 /// // the directory and everything under it is deleted when the scope exits
 /// </code>
 /// </summary>
@@ -25,16 +25,4 @@ public interface ITemporaryDirectory : IDisposable, IAsyncDisposable
 
     /// <summary>Whether the directory currently exists on disk.</summary>
     bool Exists { get; }
-
-    /// <summary>
-    /// Combines this directory's path with one or more relative segments to produce an absolute
-    /// path inside the temporary directory. This is pure path arithmetic and performs no I/O; the
-    /// returned path is not guaranteed to exist.
-    /// </summary>
-    /// <param name="relativeSegments">
-    /// Relative path segments to append. Passing no segments returns <see cref="Path"/>.
-    /// </param>
-    /// <returns>The combined absolute path.</returns>
-    /// <exception cref="ArgumentException">A segment contains invalid path characters.</exception>
-    string Combine(params string[] relativeSegments);
 }

--- a/src/NexusLabs.Framework/IO/ITemporaryDirectory.cs
+++ b/src/NexusLabs.Framework/IO/ITemporaryDirectory.cs
@@ -1,0 +1,40 @@
+namespace NexusLabs.Framework.IO;
+
+/// <summary>
+/// A temporary directory that deletes itself (and its entire contents) when disposed. Obtain one
+/// from <see cref="ITemporaryDirectoryFactory"/> and bind its lifetime to a scope with
+/// <c>using</c> / <c>await using</c>:
+/// <code>
+/// await using var dir = factory.Create();
+/// await File.WriteAllTextAsync(dir.Combine("data.txt"), "...", cancellationToken);
+/// // the directory and everything under it is deleted when the scope exits
+/// </code>
+/// </summary>
+/// <remarks>
+/// Disposal is idempotent, thread-safe, and never throws. Cleanup failures (for example a file
+/// still locked on Windows) are routed to the handler configured at creation time
+/// (<see cref="TemporaryDirectoryOptions.OnCleanupError"/>) rather than thrown. On Windows, dispose
+/// any streams you opened under this directory <em>before</em> disposing the handle, otherwise the
+/// delete may fail and surface through that handler. Supply a
+/// <see cref="TemporaryDirectoryOptions.DeleteExecutor"/> to retry transient lock failures.
+/// </remarks>
+public interface ITemporaryDirectory : IDisposable, IAsyncDisposable
+{
+    /// <summary>The absolute path to the temporary directory.</summary>
+    string Path { get; }
+
+    /// <summary>Whether the directory currently exists on disk.</summary>
+    bool Exists { get; }
+
+    /// <summary>
+    /// Combines this directory's path with one or more relative segments to produce an absolute
+    /// path inside the temporary directory. This is pure path arithmetic and performs no I/O; the
+    /// returned path is not guaranteed to exist.
+    /// </summary>
+    /// <param name="relativeSegments">
+    /// Relative path segments to append. Passing no segments returns <see cref="Path"/>.
+    /// </param>
+    /// <returns>The combined absolute path.</returns>
+    /// <exception cref="ArgumentException">A segment contains invalid path characters.</exception>
+    string Combine(params string[] relativeSegments);
+}

--- a/src/NexusLabs.Framework/IO/ITemporaryDirectoryFactory.cs
+++ b/src/NexusLabs.Framework/IO/ITemporaryDirectoryFactory.cs
@@ -1,0 +1,29 @@
+namespace NexusLabs.Framework.IO;
+
+/// <summary>
+/// Creates <see cref="ITemporaryDirectory"/> instances. This is the mockable seam consumers depend
+/// on so their code can be unit tested without touching the real file system.
+/// </summary>
+public interface ITemporaryDirectoryFactory
+{
+    /// <summary>
+    /// Creates a new uniquely-named temporary directory using default options.
+    /// </summary>
+    /// <returns>
+    /// A disposable handle whose disposal deletes the directory and all of its contents.
+    /// </returns>
+    ITemporaryDirectory Create();
+
+    /// <summary>
+    /// Creates a new uniquely-named temporary directory using the supplied options.
+    /// </summary>
+    /// <param name="options">
+    /// Controls the root location, name prefix, cleanup-failure handling, and optional delete
+    /// resilience policy.
+    /// </param>
+    /// <returns>
+    /// A disposable handle whose disposal deletes the directory and all of its contents.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    ITemporaryDirectory Create(TemporaryDirectoryOptions options);
+}

--- a/src/NexusLabs.Framework/IO/ITemporaryFile.cs
+++ b/src/NexusLabs.Framework/IO/ITemporaryFile.cs
@@ -1,0 +1,28 @@
+namespace NexusLabs.Framework.IO;
+
+/// <summary>
+/// A temporary file that deletes itself when disposed. Obtain one from
+/// <see cref="ITemporaryFileFactory"/> and bind its lifetime to a scope with <c>using</c> /
+/// <c>await using</c>:
+/// <code>
+/// await using var file = factory.Create();
+/// await File.WriteAllTextAsync(file.Path, "...", cancellationToken);
+/// // the file is deleted when the scope exits
+/// </code>
+/// </summary>
+/// <remarks>
+/// Disposal is idempotent, thread-safe, and never throws. Cleanup failures (for example the file
+/// still being open on Windows) are routed to the handler configured at creation time
+/// (<see cref="TemporaryFileOptions.OnCleanupError"/>) rather than thrown. On Windows, dispose any
+/// stream you opened over this file <em>before</em> disposing the handle, otherwise the delete may
+/// fail and surface through that handler. Supply a
+/// <see cref="TemporaryFileOptions.DeleteExecutor"/> to retry transient lock failures.
+/// </remarks>
+public interface ITemporaryFile : IDisposable, IAsyncDisposable
+{
+    /// <summary>The absolute path to the temporary file.</summary>
+    string Path { get; }
+
+    /// <summary>Whether the file currently exists on disk.</summary>
+    bool Exists { get; }
+}

--- a/src/NexusLabs.Framework/IO/ITemporaryFileFactory.cs
+++ b/src/NexusLabs.Framework/IO/ITemporaryFileFactory.cs
@@ -1,0 +1,25 @@
+namespace NexusLabs.Framework.IO;
+
+/// <summary>
+/// Creates <see cref="ITemporaryFile"/> instances. This is the mockable seam consumers depend on so
+/// their code can be unit tested without touching the real file system.
+/// </summary>
+public interface ITemporaryFileFactory
+{
+    /// <summary>
+    /// Creates a new uniquely-named temporary file using default options.
+    /// </summary>
+    /// <returns>A disposable handle whose disposal deletes the file.</returns>
+    ITemporaryFile Create();
+
+    /// <summary>
+    /// Creates a new uniquely-named temporary file using the supplied options.
+    /// </summary>
+    /// <param name="options">
+    /// Controls the root location, name prefix, extension, whether the file is pre-created,
+    /// cleanup-failure handling, and optional delete resilience policy.
+    /// </param>
+    /// <returns>A disposable handle whose disposal deletes the file.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <see langword="null"/>.</exception>
+    ITemporaryFile Create(TemporaryFileOptions options);
+}

--- a/src/NexusLabs.Framework/IO/ResilientDeleteExecutor.cs
+++ b/src/NexusLabs.Framework/IO/ResilientDeleteExecutor.cs
@@ -1,0 +1,22 @@
+namespace NexusLabs.Framework.IO;
+
+/// <summary>
+/// Executes a delete operation, optionally wrapping it in a caller-supplied resilience policy
+/// (retry, backoff, timeout, jitter, ...). The signature deliberately matches the common
+/// <c>Execute(operation, cancellationToken)</c> shape used by resilience pipelines, so a policy's
+/// execute method can be supplied directly as a method group with no adapter code:
+/// <code>
+/// var options = new TemporaryDirectoryOptions { DeleteExecutor = myResiliencePolicy.ExecuteAsync };
+/// </code>
+/// </summary>
+/// <remarks>
+/// When no executor is supplied the delete is attempted exactly once. Any resilience mechanism
+/// works equally well — supply a custom lambda such as <c>(op, ct) =&gt; op(ct)</c> for a single
+/// attempt, or your own retry loop.
+/// </remarks>
+/// <param name="operation">The delete operation to execute (and potentially retry).</param>
+/// <param name="cancellationToken">A token to observe while executing the operation.</param>
+/// <returns>A task that completes when the operation and any retries finish.</returns>
+public delegate ValueTask ResilientDeleteExecutor(
+    Func<CancellationToken, ValueTask> operation,
+    CancellationToken cancellationToken);

--- a/src/NexusLabs.Framework/IO/TemporaryDirectory.cs
+++ b/src/NexusLabs.Framework/IO/TemporaryDirectory.cs
@@ -1,0 +1,58 @@
+namespace NexusLabs.Framework.IO;
+
+internal sealed class TemporaryDirectory : ITemporaryDirectory
+{
+    private readonly Func<CancellationToken, ValueTask> _deleteOnce;
+    private readonly ResilientDeleteExecutor? _executor;
+    private readonly Action<Exception>? _onCleanupError;
+    private int _disposed;
+
+    internal TemporaryDirectory(
+        string path,
+        Func<CancellationToken, ValueTask> deleteOnce,
+        ResilientDeleteExecutor? executor,
+        Action<Exception>? onCleanupError)
+    {
+        Path = path;
+        _deleteOnce = deleteOnce;
+        _executor = executor;
+        _onCleanupError = onCleanupError;
+    }
+
+    public string Path { get; }
+
+    public bool Exists => Directory.Exists(Path);
+
+    public string Combine(params string[] relativeSegments) =>
+        System.IO.Path.Combine([Path, .. relativeSegments]);
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        var error = TemporaryResourceDeleter.DeleteBlocking(_deleteOnce, _executor);
+        if (error is not null)
+        {
+            _onCleanupError?.Invoke(error);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        var error = await TemporaryResourceDeleter
+            .DeleteAsync(_deleteOnce, _executor, CancellationToken.None)
+            .ConfigureAwait(false);
+        if (error is not null)
+        {
+            _onCleanupError?.Invoke(error);
+        }
+    }
+}

--- a/src/NexusLabs.Framework/IO/TemporaryDirectory.cs
+++ b/src/NexusLabs.Framework/IO/TemporaryDirectory.cs
@@ -23,9 +23,6 @@ internal sealed class TemporaryDirectory : ITemporaryDirectory
 
     public bool Exists => Directory.Exists(Path);
 
-    public string Combine(params string[] relativeSegments) =>
-        System.IO.Path.Combine([Path, .. relativeSegments]);
-
     public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)

--- a/src/NexusLabs.Framework/IO/TemporaryDirectoryFactory.cs
+++ b/src/NexusLabs.Framework/IO/TemporaryDirectoryFactory.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace NexusLabs.Framework.IO;
+
+/// <summary>
+/// Default <see cref="ITemporaryDirectoryFactory"/> implementation. Creates uniquely-named
+/// directories under a <c>NexusLabs</c> subfolder of the system temp path (or a caller-supplied
+/// root) and hands back self-deleting <see cref="ITemporaryDirectory"/> handles.
+/// </summary>
+public sealed class TemporaryDirectoryFactory : ITemporaryDirectoryFactory
+{
+    private static readonly string DefaultRoot =
+        System.IO.Path.Combine(System.IO.Path.GetTempPath(), "NexusLabs");
+
+    private readonly TemporaryResourceLog _log;
+    private readonly Func<string, Func<CancellationToken, ValueTask>> _deleteOnceFactory;
+
+    /// <summary>
+    /// Creates a factory that does not log cleanup failures. Without a logger, supply a
+    /// <see cref="TemporaryDirectoryOptions.OnCleanupError"/> handler per creation to observe
+    /// failed cleanups.
+    /// </summary>
+    public TemporaryDirectoryFactory()
+        : this(NullLogger.Instance, TemporaryResourceDeleter.CreateDirectoryDeleteOnce)
+    {
+    }
+
+    /// <summary>
+    /// Creates a factory that logs cleanup failures via <paramref name="logger"/> whenever a
+    /// creation does not supply its own <see cref="TemporaryDirectoryOptions.OnCleanupError"/>
+    /// handler.
+    /// </summary>
+    /// <param name="logger">The logger used to report cleanup failures.</param>
+    public TemporaryDirectoryFactory(ILogger<TemporaryDirectoryFactory> logger)
+        : this(logger, TemporaryResourceDeleter.CreateDirectoryDeleteOnce)
+    {
+    }
+
+    internal TemporaryDirectoryFactory(
+        ILogger logger,
+        Func<string, Func<CancellationToken, ValueTask>> deleteOnceFactory)
+    {
+        _log = new TemporaryResourceLog(logger);
+        _deleteOnceFactory = deleteOnceFactory;
+    }
+
+    /// <inheritdoc />
+    public ITemporaryDirectory Create() => Create(new TemporaryDirectoryOptions());
+
+    /// <inheritdoc />
+    public ITemporaryDirectory Create(TemporaryDirectoryOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var root = options.RootPath ?? DefaultRoot;
+        Directory.CreateDirectory(root);
+
+        var name = (options.Prefix ?? string.Empty) + Guid.NewGuid().ToString("N");
+        var path = System.IO.Path.Combine(root, name);
+        Directory.CreateDirectory(path);
+
+        var onCleanupError = options.OnCleanupError ?? (error => _log.CleanupFailed(path, error));
+        return new TemporaryDirectory(
+            path,
+            _deleteOnceFactory(path),
+            options.DeleteExecutor,
+            onCleanupError);
+    }
+}

--- a/src/NexusLabs.Framework/IO/TemporaryDirectoryOptions.cs
+++ b/src/NexusLabs.Framework/IO/TemporaryDirectoryOptions.cs
@@ -1,0 +1,37 @@
+namespace NexusLabs.Framework.IO;
+
+/// <summary>
+/// Options controlling how an <see cref="ITemporaryDirectory"/> is created and cleaned up. All
+/// members are optional; an instance with no members set produces a uniquely-named directory under
+/// the system temp path with no special cleanup handling.
+/// </summary>
+public sealed record TemporaryDirectoryOptions
+{
+    /// <summary>
+    /// The directory under which the temporary directory is created. When <see langword="null"/>,
+    /// a <c>NexusLabs</c> subfolder of <see cref="System.IO.Path.GetTempPath"/> is used. The root is
+    /// created if it does not already exist.
+    /// </summary>
+    public string? RootPath { get; init; }
+
+    /// <summary>
+    /// An optional prefix prepended to the generated unique name. Useful for making leaked
+    /// directories easy to identify. When <see langword="null"/>, no prefix is applied.
+    /// </summary>
+    public string? Prefix { get; init; }
+
+    /// <summary>
+    /// Invoked when deletion fails during disposal, with the final exception (after any
+    /// <see cref="DeleteExecutor"/> retries are exhausted). Disposal never throws; this handler is
+    /// how a caller observes a failed cleanup. When <see langword="null"/>, the creating factory's
+    /// logger is used instead.
+    /// </summary>
+    public Action<Exception>? OnCleanupError { get; init; }
+
+    /// <summary>
+    /// An optional resilience policy used to execute the delete during disposal — for example a
+    /// retry/backoff pipeline's execute method supplied as a method group. When
+    /// <see langword="null"/>, the delete is attempted exactly once.
+    /// </summary>
+    public ResilientDeleteExecutor? DeleteExecutor { get; init; }
+}

--- a/src/NexusLabs.Framework/IO/TemporaryFile.cs
+++ b/src/NexusLabs.Framework/IO/TemporaryFile.cs
@@ -1,0 +1,55 @@
+namespace NexusLabs.Framework.IO;
+
+internal sealed class TemporaryFile : ITemporaryFile
+{
+    private readonly Func<CancellationToken, ValueTask> _deleteOnce;
+    private readonly ResilientDeleteExecutor? _executor;
+    private readonly Action<Exception>? _onCleanupError;
+    private int _disposed;
+
+    internal TemporaryFile(
+        string path,
+        Func<CancellationToken, ValueTask> deleteOnce,
+        ResilientDeleteExecutor? executor,
+        Action<Exception>? onCleanupError)
+    {
+        Path = path;
+        _deleteOnce = deleteOnce;
+        _executor = executor;
+        _onCleanupError = onCleanupError;
+    }
+
+    public string Path { get; }
+
+    public bool Exists => File.Exists(Path);
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        var error = TemporaryResourceDeleter.DeleteBlocking(_deleteOnce, _executor);
+        if (error is not null)
+        {
+            _onCleanupError?.Invoke(error);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        var error = await TemporaryResourceDeleter
+            .DeleteAsync(_deleteOnce, _executor, CancellationToken.None)
+            .ConfigureAwait(false);
+        if (error is not null)
+        {
+            _onCleanupError?.Invoke(error);
+        }
+    }
+}

--- a/src/NexusLabs.Framework/IO/TemporaryFileFactory.cs
+++ b/src/NexusLabs.Framework/IO/TemporaryFileFactory.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace NexusLabs.Framework.IO;
+
+/// <summary>
+/// Default <see cref="ITemporaryFileFactory"/> implementation. Creates uniquely-named files under a
+/// <c>NexusLabs</c> subfolder of the system temp path (or a caller-supplied root) and hands back
+/// self-deleting <see cref="ITemporaryFile"/> handles.
+/// </summary>
+public sealed class TemporaryFileFactory : ITemporaryFileFactory
+{
+    private static readonly string DefaultRoot =
+        System.IO.Path.Combine(System.IO.Path.GetTempPath(), "NexusLabs");
+
+    private readonly TemporaryResourceLog _log;
+    private readonly Func<string, Func<CancellationToken, ValueTask>> _deleteOnceFactory;
+
+    /// <summary>
+    /// Creates a factory that does not log cleanup failures. Without a logger, supply a
+    /// <see cref="TemporaryFileOptions.OnCleanupError"/> handler per creation to observe failed
+    /// cleanups.
+    /// </summary>
+    public TemporaryFileFactory()
+        : this(NullLogger.Instance, TemporaryResourceDeleter.CreateFileDeleteOnce)
+    {
+    }
+
+    /// <summary>
+    /// Creates a factory that logs cleanup failures via <paramref name="logger"/> whenever a
+    /// creation does not supply its own <see cref="TemporaryFileOptions.OnCleanupError"/> handler.
+    /// </summary>
+    /// <param name="logger">The logger used to report cleanup failures.</param>
+    public TemporaryFileFactory(ILogger<TemporaryFileFactory> logger)
+        : this(logger, TemporaryResourceDeleter.CreateFileDeleteOnce)
+    {
+    }
+
+    internal TemporaryFileFactory(
+        ILogger logger,
+        Func<string, Func<CancellationToken, ValueTask>> deleteOnceFactory)
+    {
+        _log = new TemporaryResourceLog(logger);
+        _deleteOnceFactory = deleteOnceFactory;
+    }
+
+    /// <inheritdoc />
+    public ITemporaryFile Create() => Create(new TemporaryFileOptions());
+
+    /// <inheritdoc />
+    public ITemporaryFile Create(TemporaryFileOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var root = options.RootPath ?? DefaultRoot;
+        Directory.CreateDirectory(root);
+
+        var name = (options.Prefix ?? string.Empty)
+            + Guid.NewGuid().ToString("N")
+            + (options.Extension ?? string.Empty);
+        var path = System.IO.Path.Combine(root, name);
+
+        if (options.CreateEmptyFile)
+        {
+            using var stream = new FileStream(
+                path,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None);
+        }
+
+        var onCleanupError = options.OnCleanupError ?? (error => _log.CleanupFailed(path, error));
+        return new TemporaryFile(
+            path,
+            _deleteOnceFactory(path),
+            options.DeleteExecutor,
+            onCleanupError);
+    }
+}

--- a/src/NexusLabs.Framework/IO/TemporaryFileOptions.cs
+++ b/src/NexusLabs.Framework/IO/TemporaryFileOptions.cs
@@ -1,0 +1,52 @@
+namespace NexusLabs.Framework.IO;
+
+/// <summary>
+/// Options controlling how an <see cref="ITemporaryFile"/> is created and cleaned up. All members
+/// are optional; an instance with no members set produces a uniquely-named, pre-created file under
+/// the system temp path with no special cleanup handling.
+/// </summary>
+public sealed record TemporaryFileOptions
+{
+    /// <summary>
+    /// The directory under which the temporary file is created. When <see langword="null"/>, a
+    /// <c>NexusLabs</c> subfolder of <see cref="System.IO.Path.GetTempPath"/> is used. The root is
+    /// created if it does not already exist.
+    /// </summary>
+    public string? RootPath { get; init; }
+
+    /// <summary>
+    /// An optional prefix prepended to the generated unique name. Useful for making leaked files
+    /// easy to identify. When <see langword="null"/>, no prefix is applied.
+    /// </summary>
+    public string? Prefix { get; init; }
+
+    /// <summary>
+    /// An optional file extension (including the leading dot, e.g. <c>".tmp"</c>) appended to the
+    /// generated unique name. When <see langword="null"/>, no extension is applied.
+    /// </summary>
+    public string? Extension { get; init; }
+
+    /// <summary>
+    /// Whether to create an empty file immediately so that <see cref="ITemporaryFile.Exists"/> is
+    /// <see langword="true"/> right after creation, mirroring
+    /// <see cref="System.IO.Path.GetTempFileName"/>. When <see langword="false"/>, only the name is
+    /// reserved and the file does not exist until the caller writes it. Defaults to
+    /// <see langword="true"/>.
+    /// </summary>
+    public bool CreateEmptyFile { get; init; } = true;
+
+    /// <summary>
+    /// Invoked when deletion fails during disposal, with the final exception (after any
+    /// <see cref="DeleteExecutor"/> retries are exhausted). Disposal never throws; this handler is
+    /// how a caller observes a failed cleanup. When <see langword="null"/>, the creating factory's
+    /// logger is used instead.
+    /// </summary>
+    public Action<Exception>? OnCleanupError { get; init; }
+
+    /// <summary>
+    /// An optional resilience policy used to execute the delete during disposal — for example a
+    /// retry/backoff pipeline's execute method supplied as a method group. When
+    /// <see langword="null"/>, the delete is attempted exactly once.
+    /// </summary>
+    public ResilientDeleteExecutor? DeleteExecutor { get; init; }
+}

--- a/src/NexusLabs.Framework/IO/TemporaryResourceDeleter.cs
+++ b/src/NexusLabs.Framework/IO/TemporaryResourceDeleter.cs
@@ -1,0 +1,112 @@
+namespace NexusLabs.Framework.IO;
+
+/// <summary>
+/// Shared deletion engine for temporary files and directories. Splits cleanup into a
+/// read-only-clearing, reparse-point-safe <em>delete-once</em> operation and a resilience wrapper
+/// that runs it through an optional <see cref="ResilientDeleteExecutor"/>. The final outcome is
+/// returned as an <see cref="Exception"/> (never thrown) so callers can surface it however they
+/// choose; an already-deleted resource is treated as success.
+/// </summary>
+internal static class TemporaryResourceDeleter
+{
+    internal static Func<CancellationToken, ValueTask> CreateDirectoryDeleteOnce(string path) =>
+        _ =>
+        {
+            DeleteDirectory(path);
+            return ValueTask.CompletedTask;
+        };
+
+    internal static Func<CancellationToken, ValueTask> CreateFileDeleteOnce(string path) =>
+        _ =>
+        {
+            DeleteFile(path);
+            return ValueTask.CompletedTask;
+        };
+
+    internal static async ValueTask<Exception?> DeleteAsync(
+        Func<CancellationToken, ValueTask> deleteOnce,
+        ResilientDeleteExecutor? executor,
+        CancellationToken cancellationToken)
+    {
+        var error = await Try
+            .Async(async () =>
+            {
+                if (executor is null)
+                {
+                    await deleteOnce(cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await executor(deleteOnce, cancellationToken).ConfigureAwait(false);
+                }
+            })
+            .ConfigureAwait(false);
+
+        return Normalize(error);
+    }
+
+    internal static Exception? DeleteBlocking(
+        Func<CancellationToken, ValueTask> deleteOnce,
+        ResilientDeleteExecutor? executor)
+    {
+        var pending = DeleteAsync(deleteOnce, executor, CancellationToken.None);
+        return pending.IsCompleted
+            ? pending.Result
+            : pending.AsTask().GetAwaiter().GetResult();
+    }
+
+    private static Exception? Normalize(Exception? error) =>
+        error is DirectoryNotFoundException or FileNotFoundException
+            ? null
+            : error;
+
+    private static void DeleteDirectory(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        var directory = new DirectoryInfo(path);
+        foreach (var child in directory.GetFileSystemInfos())
+        {
+            if (child.Attributes.HasFlag(FileAttributes.ReparsePoint))
+            {
+                ClearReadOnly(child);
+                child.Delete();
+            }
+            else if (child is DirectoryInfo childDirectory)
+            {
+                DeleteDirectory(childDirectory.FullName);
+            }
+            else
+            {
+                ClearReadOnly(child);
+                child.Delete();
+            }
+        }
+
+        ClearReadOnly(directory);
+        directory.Delete(recursive: false);
+    }
+
+    private static void DeleteFile(string path)
+    {
+        var file = new FileInfo(path);
+        if (!file.Exists)
+        {
+            return;
+        }
+
+        ClearReadOnly(file);
+        file.Delete();
+    }
+
+    private static void ClearReadOnly(FileSystemInfo info)
+    {
+        if (info.Attributes.HasFlag(FileAttributes.ReadOnly))
+        {
+            info.Attributes &= ~FileAttributes.ReadOnly;
+        }
+    }
+}

--- a/src/NexusLabs.Framework/IO/TemporaryResourceLog.cs
+++ b/src/NexusLabs.Framework/IO/TemporaryResourceLog.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+
+namespace NexusLabs.Framework.IO;
+
+/// <summary>
+/// Source-generated log messages emitted by the temporary file/directory factories when cleanup
+/// fails and no caller-supplied <c>OnCleanupError</c> handler is configured.
+/// </summary>
+internal sealed partial class TemporaryResourceLog(ILogger logger)
+{
+    /// <summary>
+    /// The <see cref="EventId"/> identifier used by <see cref="CleanupFailed"/>.
+    /// </summary>
+    internal const int CleanupFailedEventId = 1001;
+
+    [LoggerMessage(
+        EventId = CleanupFailedEventId,
+        Level = LogLevel.Warning,
+        Message = "Failed to delete temporary resource at {Path}")]
+    public partial void CleanupFailed(string path, Exception exception);
+}

--- a/src/NexusLabs.Framework/NexusLabs.Framework.csproj
+++ b/src/NexusLabs.Framework/NexusLabs.Framework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Description>Cross-cutting C# utilities for Nexus Software Labs projects: result pattern (Tried/TriedEx/TriedNullEx + Safely + Try orchestration) with optional disposal of disposable wrapped values, [TransfersOwnership] ownership-transfer attribute, stream wrappers (StreamWithLength, ReadOnlySubstream, StreamPump), AsyncSemaphoreLease concurrency primitive with timeout-bounded acquisition, ITracer/Tracer over ActivitySource, async-aware event handler extensions, process diagnostics helpers, and async ADO.NET interface shapes.</Description>
+    <Description>Cross-cutting C# utilities for Nexus Software Labs projects: result pattern (Tried/TriedEx/TriedNullEx + Safely + Try orchestration) with optional disposal of disposable wrapped values, [TransfersOwnership] ownership-transfer attribute, stream wrappers (StreamWithLength, ReadOnlySubstream, StreamPump), self-deleting temporary file/directory primitives (ITemporaryFile/ITemporaryDirectory + factories) with a pluggable delete-resilience seam, AsyncSemaphoreLease concurrency primitive with timeout-bounded acquisition, ITracer/Tracer over ActivitySource, async-aware event handler extensions, process diagnostics helpers, and async ADO.NET interface shapes.</Description>
     <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/master/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/tests/NexusLabs.Framework.Tests/IO/TemporaryDirectoryFactoryTests.cs
+++ b/tests/NexusLabs.Framework.Tests/IO/TemporaryDirectoryFactoryTests.cs
@@ -60,7 +60,7 @@ public sealed class TemporaryDirectoryFactoryTests : IDisposable
         using (var dir = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot }))
         {
             path = dir.Path;
-            File.WriteAllText(dir.Combine("a.txt"), "hello");
+            File.WriteAllText(Path.Combine(dir.Path, "a.txt"), "hello");
             Assert.True(File.Exists(Path.Combine(path, "a.txt")), "seed file should exist");
         }
 
@@ -75,7 +75,7 @@ public sealed class TemporaryDirectoryFactoryTests : IDisposable
         await using (var dir = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot }))
         {
             path = dir.Path;
-            await File.WriteAllTextAsync(dir.Combine("a.txt"), "hello", _ct);
+            await File.WriteAllTextAsync(Path.Combine(dir.Path, "a.txt"), "hello", _ct);
         }
 
         Assert.False(Directory.Exists(path), "temp directory should be deleted after async dispose");
@@ -102,7 +102,7 @@ public sealed class TemporaryDirectoryFactoryTests : IDisposable
         using (var dir = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot }))
         {
             path = dir.Path;
-            var file = dir.Combine("ro.txt");
+            var file = Path.Combine(dir.Path, "ro.txt");
             File.WriteAllText(file, "x");
             File.SetAttributes(file, FileAttributes.ReadOnly);
         }
@@ -119,17 +119,6 @@ public sealed class TemporaryDirectoryFactoryTests : IDisposable
         using var second = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot });
 
         Assert.NotEqual(first.Path, second.Path);
-    }
-
-    [Fact]
-    public void Combine_ReturnsPathInsideDirectory()
-    {
-        var factory = new TemporaryDirectoryFactory();
-        using var dir = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot });
-
-        var combined = dir.Combine("sub", "file.txt");
-
-        Assert.Equal(Path.Combine(dir.Path, "sub", "file.txt"), combined);
     }
 
     [Fact]

--- a/tests/NexusLabs.Framework.Tests/IO/TemporaryDirectoryFactoryTests.cs
+++ b/tests/NexusLabs.Framework.Tests/IO/TemporaryDirectoryFactoryTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using NexusLabs.Framework.IO;
+
+using Xunit;
+
+namespace NexusLabs.Framework.Tests.IO;
+
+public sealed class TemporaryDirectoryFactoryTests : IDisposable
+{
+    private readonly CancellationToken _ct = TestContext.Current.CancellationToken;
+    private readonly string _testRoot =
+        Path.Combine(Path.GetTempPath(), "nlf-tdf-tests-" + Guid.NewGuid().ToString("N"));
+
+    public TemporaryDirectoryFactoryTests() => Directory.CreateDirectory(_testRoot);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Create_CreatesDirectoryThatExists()
+    {
+        var factory = new TemporaryDirectoryFactory();
+
+        using var dir = factory.Create();
+
+        Assert.True(Directory.Exists(dir.Path), "temp directory should exist after Create");
+    }
+
+    [Fact]
+    public void Create_HonorsRootPathAndPrefix()
+    {
+        var factory = new TemporaryDirectoryFactory();
+        var options = new TemporaryDirectoryOptions { RootPath = _testRoot, Prefix = "pfx-" };
+
+        using var dir = factory.Create(options);
+
+        Assert.Equal(_testRoot, Path.GetDirectoryName(dir.Path));
+        Assert.StartsWith("pfx-", Path.GetFileName(dir.Path));
+    }
+
+    [Fact]
+    public void Dispose_DeletesDirectoryAndContents()
+    {
+        var factory = new TemporaryDirectoryFactory();
+        string path;
+        using (var dir = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot }))
+        {
+            path = dir.Path;
+            File.WriteAllText(dir.Combine("a.txt"), "hello");
+            Assert.True(File.Exists(Path.Combine(path, "a.txt")), "seed file should exist");
+        }
+
+        Assert.False(Directory.Exists(path), "temp directory should be deleted after dispose");
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DeletesDirectory()
+    {
+        var factory = new TemporaryDirectoryFactory();
+        string path;
+        await using (var dir = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot }))
+        {
+            path = dir.Path;
+            await File.WriteAllTextAsync(dir.Combine("a.txt"), "hello", _ct);
+        }
+
+        Assert.False(Directory.Exists(path), "temp directory should be deleted after async dispose");
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var factory = new TemporaryDirectoryFactory();
+        var dir = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot });
+        var path = dir.Path;
+
+        dir.Dispose();
+        dir.Dispose();
+
+        Assert.False(Directory.Exists(path), "temp directory should be deleted");
+    }
+
+    [Fact]
+    public void Dispose_DeletesDirectoryContainingReadOnlyFile()
+    {
+        var factory = new TemporaryDirectoryFactory();
+        string path;
+        using (var dir = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot }))
+        {
+            path = dir.Path;
+            var file = dir.Combine("ro.txt");
+            File.WriteAllText(file, "x");
+            File.SetAttributes(file, FileAttributes.ReadOnly);
+        }
+
+        Assert.False(Directory.Exists(path), "read-only file must not block temp directory cleanup");
+    }
+
+    [Fact]
+    public void Create_TwoCalls_ProduceDistinctPaths()
+    {
+        var factory = new TemporaryDirectoryFactory();
+
+        using var first = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot });
+        using var second = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot });
+
+        Assert.NotEqual(first.Path, second.Path);
+    }
+
+    [Fact]
+    public void Combine_ReturnsPathInsideDirectory()
+    {
+        var factory = new TemporaryDirectoryFactory();
+        using var dir = factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot });
+
+        var combined = dir.Combine("sub", "file.txt");
+
+        Assert.Equal(Path.Combine(dir.Path, "sub", "file.txt"), combined);
+    }
+
+    [Fact]
+    public void Dispose_WhenDeleteFails_InvokesOnCleanupErrorAndDoesNotThrow()
+    {
+        var boom = new IOException("locked");
+        Exception? captured = null;
+        Func<CancellationToken, ValueTask> deleteOnce = _ => throw boom;
+        var dir = new TemporaryDirectory(
+            @"X:\does-not-matter",
+            deleteOnce,
+            executor: null,
+            onCleanupError: ex => captured = ex);
+
+        dir.Dispose();
+
+        Assert.Same(boom, captured);
+    }
+
+    [Fact]
+    public void Dispose_NoOnCleanupError_LogsViaFactoryLogger()
+    {
+        var repo = new MockRepository(MockBehavior.Strict);
+        var logger = repo.Create<ILogger>();
+        logger.Setup(l => l.IsEnabled(LogLevel.Warning)).Returns(true);
+        logger.Setup(l => l.Log(
+            LogLevel.Warning,
+            It.Is<EventId>(e => e.Id == TemporaryResourceLog.CleanupFailedEventId),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<IOException>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()));
+
+        var boom = new IOException("locked");
+        var factory = new TemporaryDirectoryFactory(logger.Object, _ => (_ => throw boom));
+
+        using (factory.Create(new TemporaryDirectoryOptions { RootPath = _testRoot }))
+        {
+        }
+
+        repo.VerifyAll();
+    }
+
+    [Fact]
+    public void Dispose_WithOnCleanupError_DoesNotUseFactoryLogger()
+    {
+        var repo = new MockRepository(MockBehavior.Strict);
+        var logger = repo.Create<ILogger>();
+
+        var boom = new IOException("locked");
+        Exception? captured = null;
+        var factory = new TemporaryDirectoryFactory(logger.Object, _ => (_ => throw boom));
+
+        using (factory.Create(new TemporaryDirectoryOptions
+        {
+            RootPath = _testRoot,
+            OnCleanupError = ex => captured = ex,
+        }))
+        {
+        }
+
+        Assert.Same(boom, captured);
+        repo.VerifyAll();
+    }
+
+    [Fact]
+    public void Factory_AndHandle_AreMockable()
+    {
+        var repo = new MockRepository(MockBehavior.Strict);
+        var handle = repo.Create<ITemporaryDirectory>();
+        handle.Setup(h => h.Path).Returns(@"C:\temp\mocked");
+        var factory = repo.Create<ITemporaryDirectoryFactory>();
+        factory.Setup(f => f.Create()).Returns(handle.Object);
+
+        var result = factory.Object.Create();
+
+        Assert.Equal(@"C:\temp\mocked", result.Path);
+        repo.VerifyAll();
+    }
+}

--- a/tests/NexusLabs.Framework.Tests/IO/TemporaryFileFactoryTests.cs
+++ b/tests/NexusLabs.Framework.Tests/IO/TemporaryFileFactoryTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using NexusLabs.Framework.IO;
+
+using Xunit;
+
+namespace NexusLabs.Framework.Tests.IO;
+
+public sealed class TemporaryFileFactoryTests : IDisposable
+{
+    private readonly CancellationToken _ct = TestContext.Current.CancellationToken;
+    private readonly string _testRoot =
+        Path.Combine(Path.GetTempPath(), "nlf-tff-tests-" + Guid.NewGuid().ToString("N"));
+
+    public TemporaryFileFactoryTests() => Directory.CreateDirectory(_testRoot);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Create_CreatesFileThatExists()
+    {
+        var factory = new TemporaryFileFactory();
+
+        using var file = factory.Create(new TemporaryFileOptions { RootPath = _testRoot });
+
+        Assert.True(File.Exists(file.Path), "temp file should exist after Create");
+    }
+
+    [Fact]
+    public void Create_WithCreateEmptyFileFalse_DoesNotCreateFile()
+    {
+        var factory = new TemporaryFileFactory();
+
+        using var file = factory.Create(new TemporaryFileOptions
+        {
+            RootPath = _testRoot,
+            CreateEmptyFile = false,
+        });
+
+        Assert.False(File.Exists(file.Path), "file should not exist when CreateEmptyFile is false");
+    }
+
+    [Fact]
+    public void Create_HonorsExtension()
+    {
+        var factory = new TemporaryFileFactory();
+
+        using var file = factory.Create(new TemporaryFileOptions
+        {
+            RootPath = _testRoot,
+            Extension = ".tmp",
+        });
+
+        Assert.EndsWith(".tmp", file.Path);
+    }
+
+    [Fact]
+    public void Dispose_DeletesFile()
+    {
+        var factory = new TemporaryFileFactory();
+        string path;
+        using (var file = factory.Create(new TemporaryFileOptions { RootPath = _testRoot }))
+        {
+            path = file.Path;
+            Assert.True(File.Exists(path), "temp file should exist before dispose");
+        }
+
+        Assert.False(File.Exists(path), "temp file should be deleted after dispose");
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DeletesFile()
+    {
+        var factory = new TemporaryFileFactory();
+        string path;
+        await using (var file = factory.Create(new TemporaryFileOptions { RootPath = _testRoot }))
+        {
+            path = file.Path;
+            await File.WriteAllTextAsync(file.Path, "data", _ct);
+        }
+
+        Assert.False(File.Exists(path), "temp file should be deleted after async dispose");
+    }
+
+    [Fact]
+    public void Dispose_DeletesReadOnlyFile()
+    {
+        var factory = new TemporaryFileFactory();
+        string path;
+        using (var file = factory.Create(new TemporaryFileOptions { RootPath = _testRoot }))
+        {
+            path = file.Path;
+            File.SetAttributes(path, FileAttributes.ReadOnly);
+        }
+
+        Assert.False(File.Exists(path), "read-only temp file should be deleted on dispose");
+    }
+
+    [Fact]
+    public void Create_TwoCalls_ProduceDistinctPaths()
+    {
+        var factory = new TemporaryFileFactory();
+
+        using var first = factory.Create(new TemporaryFileOptions { RootPath = _testRoot });
+        using var second = factory.Create(new TemporaryFileOptions { RootPath = _testRoot });
+
+        Assert.NotEqual(first.Path, second.Path);
+    }
+
+    [Fact]
+    public void Dispose_WhenFileLocked_InvokesOnCleanupErrorOnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Skip("Deleting an open file only fails on Windows.");
+        }
+
+        var factory = new TemporaryFileFactory();
+        Exception? captured = null;
+        var file = factory.Create(new TemporaryFileOptions
+        {
+            RootPath = _testRoot,
+            OnCleanupError = ex => captured = ex,
+        });
+
+        var stream = new FileStream(file.Path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        file.Dispose();
+        stream.Dispose();
+
+        Assert.NotNull(captured);
+        Assert.IsType<IOException>(captured);
+    }
+
+    [Fact]
+    public void Dispose_NoOnCleanupError_LogsViaFactoryLogger()
+    {
+        var repo = new MockRepository(MockBehavior.Strict);
+        var logger = repo.Create<ILogger>();
+        logger.Setup(l => l.IsEnabled(LogLevel.Warning)).Returns(true);
+        logger.Setup(l => l.Log(
+            LogLevel.Warning,
+            It.Is<EventId>(e => e.Id == TemporaryResourceLog.CleanupFailedEventId),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<IOException>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()));
+
+        var boom = new IOException("locked");
+        var factory = new TemporaryFileFactory(logger.Object, _ => (_ => throw boom));
+
+        using (factory.Create(new TemporaryFileOptions { RootPath = _testRoot, CreateEmptyFile = false }))
+        {
+        }
+
+        repo.VerifyAll();
+    }
+
+    [Fact]
+    public void Dispose_WithOnCleanupError_DoesNotUseFactoryLogger()
+    {
+        var repo = new MockRepository(MockBehavior.Strict);
+        var logger = repo.Create<ILogger>();
+
+        var boom = new IOException("locked");
+        Exception? captured = null;
+        var factory = new TemporaryFileFactory(logger.Object, _ => (_ => throw boom));
+
+        using (factory.Create(new TemporaryFileOptions
+        {
+            RootPath = _testRoot,
+            CreateEmptyFile = false,
+            OnCleanupError = ex => captured = ex,
+        }))
+        {
+        }
+
+        Assert.Same(boom, captured);
+        repo.VerifyAll();
+    }
+}

--- a/tests/NexusLabs.Framework.Tests/IO/TemporaryResourceDeleterTests.cs
+++ b/tests/NexusLabs.Framework.Tests/IO/TemporaryResourceDeleterTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NexusLabs.Framework.IO;
+
+using Xunit;
+
+namespace NexusLabs.Framework.Tests.IO;
+
+public sealed class TemporaryResourceDeleterTests
+{
+    private readonly CancellationToken _ct = TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task DeleteAsync_NoExecutor_RunsDeleteOnceExactlyOnce()
+    {
+        var attempts = 0;
+        Func<CancellationToken, ValueTask> deleteOnce = _ =>
+        {
+            attempts++;
+            return ValueTask.CompletedTask;
+        };
+
+        var error = await TemporaryResourceDeleter.DeleteAsync(deleteOnce, executor: null, _ct);
+
+        Assert.Null(error);
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_NoExecutor_Failure_ReturnsException()
+    {
+        var boom = new IOException("nope");
+        Func<CancellationToken, ValueTask> deleteOnce = _ => throw boom;
+
+        var error = await TemporaryResourceDeleter.DeleteAsync(deleteOnce, executor: null, _ct);
+
+        Assert.Same(boom, error);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_AlreadyGone_IsNormalizedToSuccess()
+    {
+        Func<CancellationToken, ValueTask> deleteOnce = _ => throw new DirectoryNotFoundException();
+
+        var error = await TemporaryResourceDeleter.DeleteAsync(deleteOnce, executor: null, _ct);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RetryExecutor_RetriesTransientFailureThenSucceeds()
+    {
+        var attempts = 0;
+        Func<CancellationToken, ValueTask> deleteOnce = _ =>
+        {
+            attempts++;
+            if (attempts < 3)
+            {
+                throw new IOException("transient lock");
+            }
+
+            return ValueTask.CompletedTask;
+        };
+
+        var error = await TemporaryResourceDeleter.DeleteAsync(deleteOnce, RetryExecutor(5), _ct);
+
+        Assert.Null(error);
+        Assert.Equal(3, attempts);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RetryExecutor_Exhausted_ReturnsFinalException()
+    {
+        var attempts = 0;
+        var boom = new IOException("always");
+        Func<CancellationToken, ValueTask> deleteOnce = _ =>
+        {
+            attempts++;
+            throw boom;
+        };
+
+        var error = await TemporaryResourceDeleter.DeleteAsync(deleteOnce, RetryExecutor(3), _ct);
+
+        Assert.Same(boom, error);
+        Assert.Equal(3, attempts);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_CustomExecutorLambda_IsHonored()
+    {
+        var executorCalls = 0;
+        ResilientDeleteExecutor executor = async (operation, ct) =>
+        {
+            executorCalls++;
+            await operation(ct);
+        };
+
+        var deleteCalls = 0;
+        Func<CancellationToken, ValueTask> deleteOnce = _ =>
+        {
+            deleteCalls++;
+            return ValueTask.CompletedTask;
+        };
+
+        var error = await TemporaryResourceDeleter.DeleteAsync(deleteOnce, executor, _ct);
+
+        Assert.Null(error);
+        Assert.Equal(1, executorCalls);
+        Assert.Equal(1, deleteCalls);
+    }
+
+    private static ResilientDeleteExecutor RetryExecutor(int maxAttempts) =>
+        async (operation, cancellationToken) =>
+        {
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                var error = await Try.Async(
+                    NullLogger.Instance,
+                    () => operation(cancellationToken).AsTask());
+                if (error is null)
+                {
+                    return;
+                }
+
+                if (attempt == maxAttempts)
+                {
+                    throw error;
+                }
+            }
+        };
+}

--- a/tests/NexusLabs.Framework.Tests/IO/TemporaryResourceLogTests.cs
+++ b/tests/NexusLabs.Framework.Tests/IO/TemporaryResourceLogTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using NexusLabs.Framework.IO;
+
+using Xunit;
+
+namespace NexusLabs.Framework.Tests.IO;
+
+public sealed class TemporaryResourceLogTests
+{
+    [Fact]
+    public void CleanupFailed_LogsWarningWithExpectedEventId()
+    {
+        var repo = new MockRepository(MockBehavior.Strict);
+        var logger = repo.Create<ILogger>();
+        logger.Setup(l => l.IsEnabled(LogLevel.Warning)).Returns(true);
+        logger.Setup(l => l.Log(
+            LogLevel.Warning,
+            It.Is<EventId>(e => e.Id == TemporaryResourceLog.CleanupFailedEventId),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<IOException>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()));
+
+        var log = new TemporaryResourceLog(logger.Object);
+        log.CleanupFailed(@"C:\temp\x", new IOException("boom"));
+
+        repo.VerifyAll();
+    }
+}

--- a/tests/NexusLabs.Framework.Tests/NexusLabs.Framework.Tests.csproj
+++ b/tests/NexusLabs.Framework.Tests/NexusLabs.Framework.Tests.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Moq" />
     <ProjectReference Include="..\..\src\NexusLabs.Framework\NexusLabs.Framework.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Adds interface-based, self-deleting temporary file and directory primitives to
`NexusLabs.Framework` (`NexusLabs.Framework.IO`) — a consistent, unit-test-friendly alternative to
the usual `Path.GetTempFileName()` + `try/finally` cleanup dance.

## What's new

- **`ITemporaryDirectory` / `ITemporaryFile`** — `IDisposable` + `IAsyncDisposable` handles used via
  `using` / `await using` (mirrors the existing `AsyncSemaphoreLease` pattern). Expose `Path`,
  `Exists`, and (directories) `Combine(...)`. Disposal is idempotent and never throws.
- **`ITemporaryDirectoryFactory` / `ITemporaryFileFactory`** (+ default implementations) — the
  mockable creation seam, so consumer code can be unit tested without touching the real file system.
  No static-class requirement.
- **`TemporaryDirectoryOptions` / `TemporaryFileOptions`** — configure root location, name prefix,
  file extension / pre-creation, cleanup-failure handling (`OnCleanupError`), and an optional
  `DeleteExecutor` resilience policy, all at creation time.
- **`ResilientDeleteExecutor`** — a delegate whose signature matches the common
  `Execute(operation, cancellationToken)` shape of resilience pipelines, so a caller can drop their
  own retry/backoff policy in as a method group with **no adapter and no third-party dependency in
  the package**.

## Cleanup behavior

Deletion clears read-only attributes, is reparse-point-safe (deletes the link, not the target),
treats an already-deleted resource as success, **never throws from `Dispose`**, and routes the final
failure to the creation-time `OnCleanupError` handler (or the factory's logger) instead of silently
giving up.

## Tests

29 new tests in `tests/NexusLabs.Framework.Tests/IO/`:

- create / exists, sync + async dispose deletion, idempotent dispose, read-only-file cleanup,
  distinct paths, `Combine`
- mockability of the factory / handle seam
- `OnCleanupError` routing (no-throw); factory-logger default asserted with exact `EventId` +
  `LogLevel`
- delete executor honored (retries a transient failure → success) and exhaustion surfaces the final
  error
- Windows-gated real file-lock failure path

**Build:** full solution **0 warnings / 0 errors** (under `TreatWarningsAsErrors` + the repo's
analyzers).
**Tests:** **286 total, 285 passed, 0 failed, 1 skipped** (the skip is a pre-existing flaky
`GenericEventExtensionTests`, unrelated to this change).

## Notes for review

- Lives in the core library's `IO/` folder — **no new package, no new dependency**.
- `<Version>` left at `0.2.4` (already tagged); the version bump is a deliberate release action.
- `CHANGELOG.md` updated under `## [Unreleased]`.
