### PR TITLE
chore(release): prepare v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ preserved at the bottom of this file for reference.
 
 ---
 
-## [Unreleased]
+## [0.2.5] &mdash; 2026-06-17
+
+Release adding self-deleting temporary file and directory primitives to `NexusLabs.Framework`.
+Per lockstep versioning every package advances to 0.2.5 together; only `NexusLabs.Framework`
+changed structurally, and the new types add no third-party dependency.
 
 ### NexusLabs.Framework
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
       of the entire monorepo; the release workflow packs + pushes every package
       at the same version.
     -->
-    <Version>0.2.4</Version>
+    <Version>0.2.5</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">


### PR DESCRIPTION
## Release v0.2.5

Lockstep release bumping every `NexusLabs.*` package to **0.2.5**.

### Included since v0.2.4

- `NexusLabs.Framework`: self-deleting temporary file / directory primitives (#13).

### Changes in this PR

- `Directory.Build.props`: `<Version>` `0.2.4` → `0.2.5`.
- `CHANGELOG.md`: finalized the `## [0.2.5]` section (dated 2026-06-17).

### Release validation (mirrors the Release workflow)

- `dotnet build -c Release`: **0 warnings / 0 errors**.
- `dotnet test -c Release`: **724 total, 723 passed, 0 failed, 1 skipped** (the skip is a
  pre-existing flaky test, unrelated).
- `dotnet pack -c Release`: all six packages produced at **0.2.5** — `NexusLabs.Framework`,
  `NexusLabs.Framework.Analyzers`, `NexusLabs.Data.Sql`, `NexusLabs.Data.Sql.MySql`,
  `NexusLabs.CodeAnalysis.Testing.TUnit`, `NexusLabs.Xunit.Assertions`.

### After merge (publishes to NuGet.org)

Tag `v0.2.5` on `master` and push the tag — the Release workflow packs and publishes every package
to NuGet.org via OIDC trusted publishing:

```
git checkout master && git pull --ff-only
git tag v0.2.5
git push origin v0.2.5
```
