### PR TITLE
chore(release): prepare v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ preserved at the bottom of this file for reference.
 
 ---
 
-## [Unreleased]
+## [0.2.6] &mdash; 2026-07-10
+
+Release adding `ArrayPool<T>` renting handles to `NexusLabs.Framework` and the NLF0024 analyzer that
+guards their use. Per lockstep versioning every package advances to 0.2.6 together; only
+`NexusLabs.Framework` and `NexusLabs.Framework.Analyzers` changed structurally, and the new types add
+no third-party dependency.
 
 ### NexusLabs.Framework
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
       of the entire monorepo; the release workflow packs + pushes every package
       at the same version.
     -->
-    <Version>0.2.5</Version>
+    <Version>0.2.6</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">


### PR DESCRIPTION
## Release v0.2.6

Lockstep release bumping every `NexusLabs.*` package to **0.2.6**.

### Included since v0.2.5

- `NexusLabs.Framework`: `ArrayPool<T>` renting handles — `RentedSpan<T>` (sync `ref struct`) and
  `RentedMemory<T>` (async reference owner) via `RentSpan`/`RentMemory` (#20).
- `NexusLabs.Framework.Analyzers`: **NLF0024**, guarding copies of `RentedSpan<T>` (#20).

### Changes in this PR

- `Directory.Build.props`: `<Version>` `0.2.5` → `0.2.6`.
- `CHANGELOG.md`: finalized the `## [0.2.6]` section (dated 2026-07-10).

### Validation

The functional change (#20) is already merged with green CI. Local build of this branch is blocked
by the pre-existing dependabot bump (#19) of `Microsoft.CodeAnalysis` to 5.6.0 versus the SDK pinned
in `global.json` (`10.0.102`, compiler 5.3.0.0) — a `master`-wide condition, not introduced here. CI
and the Release workflow validate on the correct toolchain (build + test + pack).

### After merge (publishes to NuGet.org)

Tag `v0.2.6` on `master` and push the tag — the Release workflow packs and publishes every package to
NuGet.org via OIDC trusted publishing.
