### PR TITLE
chore: sync Genesis ADR guidance

### DIFF
--- a/.github/instructions/genesis/adr.instructions.md
+++ b/.github/instructions/genesis/adr.instructions.md
@@ -1,14 +1,36 @@
 ---
-applyTo: "docs/adr/**"
+applyTo: "**/adr-*.md,**/ADR-*.md,**/*-adr-*.md,**/*-ADR-*.md,**/*-adr.md,**/*-ADR.md"
 ---
 
-# Architecture Decision Records
+# Architecture Decision Record Authoring
 
-## Location and naming
+Use these rules for every ADR, regardless of where the repository stores it.
 
-- ADRs live in `docs/adr/` at the repository root.
-- File naming: `adr-NNNN-title-slug.md` with sequential 4-digit numbering.
-- Title slugs: lowercase, hyphens, no special characters, 3-5 words.
+## Purpose
+
+An ADR records one architecturally significant decision for future readers who were
+not part of the original discussion. It must explain the problem, decision, rationale,
+scope, alternatives, and accepted consequences without requiring access to source code,
+an issue, a pull request, or conversation history.
+
+Record why the decision was made, not the chronology of how it was implemented.
+
+## Metadata and naming
+
+The default location is `docs/adr/`. Use `adr-NNNN-title-slug.md` with sequential
+4-digit numbering, a lowercase hyphenated slug, and this front matter:
+
+```yaml
+---
+title: "ADR-NNNN: Decision title"
+status: "Proposed"
+date: "YYYY-MM-DD"
+authors: []
+tags: ["architecture", "decision"]
+supersedes: ""
+superseded_by: ""
+---
+```
 
 ## Status lifecycle
 
@@ -20,36 +42,89 @@ applyTo: "docs/adr/**"
 | Superseded | Replaced by a newer ADR (set `superseded_by` field) |
 | Deprecated | No longer relevant due to changed circumstances |
 
-When superseding an existing ADR, update the old ADR's `superseded_by` front matter
-field to reference the new ADR, and set the old ADR's status to `Superseded`.
+## Decision history, not work history
 
-## Content quality
+An ADR preserves how a decision evolved, not the activity used to implement it.
 
-### Write as a permanent document
+- A Proposed ADR may change while the decision is under review.
+- Once Accepted, keep its context, decision, rationale, and consequences unchanged.
+- A short dated outcome note may record observed consequences or confirmation results.
+- A material change requires a new ADR linked through `supersedes` and `superseded_by`.
+- Issues and PRs track tasks, owners, progress, commits, and rollout activity. They may
+  be supplemental references, but the ADR must not depend on them for its meaning.
 
-ADRs are long-lived reference documents. Do not include:
+## Required content
 
-- Planning session context ("while discussing Phase 1.2B...")
-- WIP or temporal jargon ("in the previous plan we decided...")
-- Sprint/iteration references ("during Sprint 14...")
-- Conversation history ("the user mentioned that...")
+Every ADR must make the following reasoning explicit.
 
-If a specific event motivated the decision, reference it by date and substance:
+### Context and scope
 
-- ✓ "On 2026-04-07, a production outage caused by unbounded cache growth revealed the need for an eviction policy."
-- ✗ "While fixing the cache issue from last week's incident, we decided..."
+Describe the facts, forces, constraints, and problem that require a decision. State
+which systems, components, interfaces, or quality attributes the decision governs and
+what is explicitly out of scope. Distinguish verified facts from assumptions.
 
-### Evidence and objectivity
+### Decision drivers
 
-- Ground claims in codebase evidence — reference specific files, packages, or patterns.
-- Present facts and reasoning, not opinions.
-- Document both benefits and drawbacks honestly.
-- Distinguish between verified facts and assumptions.
+List the criteria that determine a good outcome, such as reliability, reversibility,
+operational cost, delivery constraints, security, or maintainability. Use these drivers
+to explain why the selected option won.
 
-## Working with existing ADRs
+### Decision
 
-- Before creating a new ADR, check if the decision is already documented.
-- When modifying code that contradicts an existing accepted ADR, flag the
-  contradiction — do not silently diverge from a documented decision.
-- When a new decision renders an existing ADR obsolete, create the new ADR
-  and update the old one rather than editing the old ADR in place.
+State the chosen direction as a clear commitment. Explain how it satisfies the decision
+drivers and where the decision applies. Do not leave the decision implicit in a list of
+implementation details.
+
+### Alternatives considered
+
+Record the serious alternatives, including the status quo when it was viable. For each,
+explain the relevant benefits, drawbacks, and why it lost against the decision drivers.
+Do not invent filler alternatives or enforce an arbitrary count.
+
+### Consequences
+
+Document positive, negative, and neutral consequences. Be explicit about tradeoffs,
+risks, follow-on constraints, and what becomes harder. Do not hide drawbacks to make the
+decision appear stronger.
+
+### Confirmation
+
+When the decision can be checked, explain how compliance or continued validity will be
+confirmed through tests, architecture rules, configuration, operational evidence, or a
+manual review. State any evidence that cannot be verified from the repository.
+
+### References
+
+List related ADRs and supplemental source material when useful. Give each reference
+enough description for the reader to understand why it is relevant.
+
+## Evidence must be understandable
+
+The ADR must contain the meaning of its evidence. A file path, symbol, package, issue,
+or link is a locator, not an explanation.
+
+- Do not use a bare citation such as `src/App/Startup.cs:42-71` as rationale.
+- Explain what the referenced artifact demonstrates and why that fact matters to the
+  decision.
+- Prefer stable identifiers such as a named type, method, module, package, configuration
+  key, or architectural boundary over mutable line ranges.
+- When an exact historical snapshot matters, use an immutable commit permalink and label
+  it as evidence from that point in time. Still summarize the evidence in the ADR.
+- Keep essential reasoning in the ADR. References are supplemental and must not be
+  required to understand the decision.
+
+Instead of writing only `Evidence: src/App/Startup.cs:42-71`, explain the fact and its
+significance: `StartupPlugin constructs every adapter directly, so adding an adapter
+changes the application composition root. StartupPlugin.ConfigureServices contains the
+current implementation.`
+
+## Write as a permanent record
+
+- Keep one decision per ADR and default to roughly one or two pages.
+- Use complete, factual sentences. Bullets may organize reasoning but must not replace it
+  with fragments.
+- Do not turn the ADR into an implementation plan or design guide.
+- Do not mention planning phases, sprints, conversation history, or what "the user" said.
+- If an event motivated the decision, identify it by date and substance.
+- Check existing ADRs before creating a new one; update supersession links instead of
+  silently contradicting or rewriting accepted decisions.


### PR DESCRIPTION
## Summary
- Replace the stale, narrow Genesis-managed ADR instruction copy with the exact current file from Genesis baseline commit `4bcd82970321cebd208411454ef77d2a283f9675`.
- Restore complete guidance for ADR purpose, metadata and naming, decision history, alternatives, consequences, confirmation, evidence, and permanence.

## Validation
- Source and target SHA-256: `A5D13068B9967C3ABD09D3F3598E7F7C26A272AE33B702482E000DCC99250592`
- `git diff --check` passed.
- Only `.github/instructions/genesis/adr.instructions.md` changed.
- Build/tests not run for this instruction-only change; PR CI is the validation path.