### PR TITLE
feat: add TUnit assertions for Tried results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Pack
         run: dotnet pack --no-build --configuration Release --output ./artifacts
 
+      - name: Verify TUnit assertions package
+        shell: pwsh
+        run: ./scripts/Verify-TUnitAssertionsPackage.ps1 -PackageDirectory ./artifacts
+
       - name: Upload package artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,43 @@ preserved at the bottom of this file for reference.
 
 ---
 
+## [Unreleased]
+
+### NexusLabs.TUnit.Assertions (new package)
+
+Added TUnit-native assertions for `NexusLabs.Framework` result types:
+
+- `Assert.That(result).Succeeded()` validates a successful `TriedEx<T>` or
+  `TriedNullEx<T>` and returns its value from `await`. `TriedEx<T>` preserves
+  its non-null value contract; `TriedNullEx<T>` preserves nullable success.
+- `Assert.That(result).Failed()` validates failure and returns the original
+  captured `Exception`. Chain `.With<TException>()` to require an assignable
+  exception type and receive the same exception instance strongly typed.
+- TUnit's `.Because(...)` context is preserved in assertion failures, and
+  failures retain the original captured exception as the inner exception.
+- **NLT0001** ships inside the same NuGet package and reports
+  `Assert.That(result.Success)`, `Assert.That(result.Value)`, and
+  `Assert.That(result.Error)`, directing callers to assert the complete result
+  with `Succeeded()` or `Failed()`.
+
+### NexusLabs.Xunit.Assertions
+
+- Refactored the existing `TrySucceeded` and `TryFailed` helpers to share one
+  framework-neutral Tried-result evaluator with the TUnit package. Public API,
+  return values, exception identity, and failure-message behavior are
+  unchanged.
+
+### Build and testing
+
+- Added first-class TUnit test-project support alongside the existing xUnit
+  default.
+- Added a post-pack consumer smoke test that installs the generated
+  `NexusLabs.TUnit.Assertions` package, runs its assertions under TUnit, and
+  verifies the bundled analyzer reports NLT0001.
+- Updated `TUnit` / `TUnit.Assertions` to 1.61.15.
+
+---
+
 ## [0.2.6] &mdash; 2026-07-10
 
 Release adding `ArrayPool<T>` renting handles to `NexusLabs.Framework` and the NLF0024 analyzer that

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,15 +53,20 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <OutputType>Exe</OutputType>
+    <NexusLabsTestFramework Condition="'$(NexusLabsTestFramework)' == ''">xunit</NexusLabsTestFramework>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))
+                    And '$(NexusLabsTestFramework)' == 'xunit'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
-    <PackageVersion Include="TUnit.Assertions" Version="1.58.0" />
+    <PackageVersion Include="TUnit" Version="1.61.15" />
+    <PackageVersion Include="TUnit.Assertions" Version="1.61.15" />
   </ItemGroup>
 
   <ItemGroup Label="Logging">

--- a/NexusLabs.slnx
+++ b/NexusLabs.slnx
@@ -16,6 +16,8 @@
     <Project Path="src/NexusLabs.Framework/NexusLabs.Framework.csproj" />
     <Project Path="src/NexusLabs.Framework.Analyzers/NexusLabs.Framework.Analyzers.csproj" />
     <Project Path="src/NexusLabs.Framework.Analyzers.CodeFixes/NexusLabs.Framework.Analyzers.CodeFixes.csproj" />
+    <Project Path="src/NexusLabs.TUnit.Assertions/NexusLabs.TUnit.Assertions.csproj" />
+    <Project Path="src/NexusLabs.TUnit.Assertions.Analyzers/NexusLabs.TUnit.Assertions.Analyzers.csproj" />
     <Project Path="src/NexusLabs.Xunit.Assertions/NexusLabs.Xunit.Assertions.csproj" />
   </Folder>
   <Folder Name="/tests/">
@@ -25,5 +27,6 @@
     <Project Path="tests/NexusLabs.Framework.Analyzers.Tests/NexusLabs.Framework.Analyzers.Tests.csproj" />
     <Project Path="tests/NexusLabs.Framework.Tests/NexusLabs.Framework.Tests.csproj" />
     <Project Path="tests/NexusLabs.Xunit.Assertions.Tests/NexusLabs.Xunit.Assertions.Tests.csproj" />
+    <Project Path="tests/TUnit/NexusLabs.TUnit.Assertions.Tests/NexusLabs.TUnit.Assertions.Tests.csproj" />
   </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A multi-package repository for cross-cutting NexusLabs C# tooling. Currently shi
 | [`NexusLabs.Framework`](https://www.nuget.org/packages/NexusLabs.Framework) | Runtime utilities: result pattern (`Tried`/`TriedEx`/`TriedNullEx`), `Try` orchestration, stream wrappers, `AsyncSemaphoreLease` concurrency primitive, `ArrayPool` renting handles (`RentedSpan`/`RentedMemory`), async event-handler helpers, async ADO.NET interface shapes, process diagnostics. |
 | [`NexusLabs.Framework.Analyzers`](https://www.nuget.org/packages/NexusLabs.Framework.Analyzers) | Roslyn analyzers for codebase hygiene and correct use of `NexusLabs.Framework` types. Test-specific and data-layer analyzers ship in separate packages. |
 | [`NexusLabs.Xunit.Assertions`](https://www.nuget.org/packages/NexusLabs.Xunit.Assertions) | xUnit.v3 assertion helpers that integrate with the Framework result-pattern types and HTTP response shapes. Uses C# 14 `extension(Assert)` blocks. |
+| [`NexusLabs.TUnit.Assertions`](https://www.nuget.org/packages/NexusLabs.TUnit.Assertions) | TUnit-native assertions for `TriedEx` and `TriedNullEx`. `Succeeded()` and `Failed()` validate the complete result and return the successful value or captured exception from `await`. Includes the NLT0001 usage analyzer. |
 | [`NexusLabs.CodeAnalysis.Testing.TUnit`](https://www.nuget.org/packages/NexusLabs.CodeAnalysis.Testing.TUnit) | TUnit-flavored `IVerifier` for `Microsoft.CodeAnalysis.Testing`. Lets TUnit-based test projects use the full `CSharpAnalyzerTest<TAnalyzer, TVerifier>` harness, which Microsoft ships verifiers for in xUnit/NUnit/MSTest but not TUnit. |
 | [`NexusLabs.Data.Sql`](https://www.nuget.org/packages/NexusLabs.Data.Sql) | Provider-agnostic decorators around `IAsyncDbConnection`/`IAsyncDbCommand`: bounded connection-lease (built on `AsyncSemaphoreLease`), open-tracking diagnostics, `ILogger` command logging, predicate-built factory. |
 | [`NexusLabs.Data.Sql.MySql`](https://www.nuget.org/packages/NexusLabs.Data.Sql.MySql) | MySQL provider for the `NexusLabs.Data.Sql` surface and `IAsyncDb*` interfaces. Builds connection strings safely via `MySqlConnectionStringBuilder`. |
@@ -17,12 +18,15 @@ A multi-package repository for cross-cutting NexusLabs C# tooling. Currently shi
 dotnet add package NexusLabs.Framework
 dotnet add package NexusLabs.Framework.Analyzers # opt-in lint rules
 dotnet add package NexusLabs.Xunit.Assertions    # only in test projects
+dotnet add package NexusLabs.TUnit.Assertions    # TUnit assertions + bundled analyzer
 dotnet add package NexusLabs.CodeAnalysis.Testing.TUnit  # for TUnit-based analyzer test projects
 dotnet add package NexusLabs.Data.Sql            # provider-agnostic decorators
 dotnet add package NexusLabs.Data.Sql.MySql      # adds MySql.Data backed factory
 ```
 
-Both packages target `net10.0`. For earlier .NET versions, pin to a 0.1.x of `NexusLabs.Framework`.
+Runtime packages target `net10.0`; Roslyn analyzer assemblies target
+`netstandard2.0`. For earlier .NET versions, pin to a 0.1.x of
+`NexusLabs.Framework`.
 
 ## What's in `NexusLabs.Framework`
 
@@ -47,6 +51,37 @@ result.Match(
     onSuccess: value => Console.WriteLine($"parsed: {value}"),
     onError: ex => Console.WriteLine($"failed: {ex.Message}"));
 ```
+
+## TUnit result assertions
+
+`NexusLabs.TUnit.Assertions` integrates the result pattern with TUnit's native
+fluent assertions:
+
+```csharp
+using NexusLabs.Framework;
+using NexusLabs.TUnit.Assertions;
+
+TriedEx<ThingId> result =
+    await service.TryCreateAsync(input, userId, cancellationToken);
+
+var thingId = await Assert.That(result)
+    .Succeeded()
+    .Because("The service should create the thing");
+```
+
+Failure assertions return the original exception and can require an assignable
+exception type:
+
+```csharp
+var error = await Assert.That(result)
+    .Failed()
+    .With<ArgumentException>()
+    .Because("Invalid input should be rejected");
+```
+
+The package includes **NLT0001**, which reports direct assertions such as
+`Assert.That(result.Success)` and points callers to the result-level
+`Succeeded()` / `Failed()` API.
 
 ## Archived packages
 

--- a/docs/analyzers/NLT0001.md
+++ b/docs/analyzers/NLT0001.md
@@ -1,0 +1,100 @@
+# NLT0001 — Assert Tried results directly
+
+**Severity:** Warning · **Category:** Usage · **Code-fix:** No
+
+`NexusLabs.TUnit.Assertions` provides assertions that validate a complete
+`TriedEx<T>` or `TriedNullEx<T>` and return the successful value or captured
+exception. Passing `Success`, `Value`, or `Error` to `Assert.That(...)` splits
+that operation into separate checks, produces weaker failure output, and
+encourages manual unwrapping.
+
+NLT0001 ships inside the `NexusLabs.TUnit.Assertions` NuGet package. No
+separate analyzer package is required.
+
+## Bad — assert `Success`, then unwrap manually
+
+```csharp
+TriedEx<ThingId> result =
+    await service.TryCreateAsync(input, userId, cancellationToken);
+
+await Assert.That(result.Success)
+    .IsTrue()
+    .Because("The service should create the thing");
+
+var thingId = result.Value;
+```
+
+## Good — assert the result and receive the value
+
+```csharp
+TriedEx<ThingId> result =
+    await service.TryCreateAsync(input, userId, cancellationToken);
+
+var thingId = await Assert.That(result)
+    .Succeeded()
+    .Because("The service should create the thing");
+```
+
+`Succeeded()` returns `T` for `TriedEx<T>` and `T?` for
+`TriedNullEx<T>`.
+
+## Bad — assert and inspect `Error` separately
+
+```csharp
+await Assert.That(result.Success)
+    .IsFalse()
+    .Because("Invalid input should be rejected");
+
+await Assert.That(result.Error)
+    .IsTypeOf<ArgumentException>();
+```
+
+## Good — assert failure and receive the exception
+
+```csharp
+var error = await Assert.That(result)
+    .Failed()
+    .With<ArgumentException>()
+    .Because("Invalid input should be rejected");
+```
+
+`Failed()` returns the original captured exception. `With<TException>()`
+accepts derived exception types and returns the same exception instance typed
+as `TException`.
+
+## What the analyzer reports
+
+NLT0001 reports calls to TUnit's `Assert.That(...)` when its direct argument is
+one of these properties on `NexusLabs.Framework.TriedEx<T>` or
+`NexusLabs.Framework.TriedNullEx<T>`:
+
+- `Success`
+- `Value`
+- `Error`
+
+The analyzer resolves the TUnit and NexusLabs symbols semantically. Unrelated
+types named `Assert`, `TriedEx`, or `TriedNullEx` are not reported.
+
+## What it does not report
+
+- asserting the complete result before calling `Succeeded()` or `Failed()`
+- ordinary production control flow such as `if (result.Success)`
+- guarded `Value` / `Error` access outside a TUnit `Assert.That(...)` call
+- assertions from another test framework
+
+## When to suppress
+
+Prefer the result-level assertions. If a test intentionally verifies the
+individual result-type properties themselves, suppress the diagnostic around
+that assertion with a reason:
+
+```csharp
+#pragma warning disable NLT0001 // This test verifies the Success property contract.
+await Assert.That(result.Success).IsTrue();
+#pragma warning restore NLT0001
+```
+
+## Related rules
+
+- **NLF0002** — guard `Value` access with a successful result check.
+- **NLF0003** — guard `Error` access with a failed result check.

--- a/docs/analyzers/README.md
+++ b/docs/analyzers/README.md
@@ -9,6 +9,9 @@ These pages are linked from each diagnostic's `helpLinkUri` and are the
 canonical explanation surfaced in IDE quick-info and tooling that follows
 build-output URLs (including LLM consumers).
 
+`NLF` rules ship in `NexusLabs.Framework.Analyzers`. `NLT` rules ship inside
+`NexusLabs.TUnit.Assertions`.
+
 ## Rules
 
 | ID | Title | Severity | Category |
@@ -36,3 +39,4 @@ build-output URLs (including LLM consumers).
 | [NLF0021](NLF0021.md) | Create Moq mocks from a MockRepository, not 'new Mock&lt;T&gt;()' or 'Mock.Of&lt;T&gt;()' | Warning | Usage |
 | [NLF0022](NLF0022.md) | Moq mocks must use MockBehavior.Strict | Warning | Usage |
 | [NLF0023](NLF0023.md) | Match value types and records with an exact value or It.Is&lt;T&gt;, not It.IsAny&lt;T&gt; | Warning | Usage |
+| [NLT0001](NLT0001.md) | Assert Tried results directly with TUnit | Warning | Usage |

--- a/scripts/Verify-TUnitAssertionsPackage.ps1
+++ b/scripts/Verify-TUnitAssertionsPackage.ps1
@@ -1,0 +1,195 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$PackageDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+
+$resolvedPackageDirectory = (Resolve-Path -LiteralPath $PackageDirectory).Path
+$packages = @(
+    Get-ChildItem `
+    -LiteralPath $resolvedPackageDirectory `
+    -Filter 'NexusLabs.TUnit.Assertions.*.nupkg'
+)
+
+if ($packages.Count -ne 1)
+{
+    throw "Expected exactly one NexusLabs.TUnit.Assertions package in '$resolvedPackageDirectory' but found $($packages.Count)."
+}
+
+$package = $packages[0]
+$packagePrefix = 'NexusLabs.TUnit.Assertions.'
+$packageVersion = $package.BaseName.Substring($packagePrefix.Length)
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+[xml]$packageVersions = Get-Content `
+    -LiteralPath (Join-Path $repositoryRoot 'Directory.Packages.props')
+$tunitVersion = $packageVersions.Project.ItemGroup.PackageVersion |
+    Where-Object Include -EQ 'TUnit' |
+    Select-Object -ExpandProperty Version -First 1
+
+if ([string]::IsNullOrWhiteSpace($tunitVersion))
+{
+    throw 'The centrally managed TUnit package version could not be resolved.'
+}
+
+$workRoot = Join-Path `
+    ([System.IO.Path]::GetTempPath()) `
+    "NexusLabs.TUnit.Assertions.PackageSmoke-$([Guid]::NewGuid().ToString('N'))"
+
+try
+{
+    $validProjectDirectory = Join-Path $workRoot 'ValidConsumer'
+    $analyzerProjectDirectory = Join-Path $workRoot 'AnalyzerConsumer'
+    New-Item -ItemType Directory -Path $validProjectDirectory | Out-Null
+    New-Item -ItemType Directory -Path $analyzerProjectDirectory | Out-Null
+
+    $escapedPackageDirectory =
+        [System.Security.SecurityElement]::Escape($resolvedPackageDirectory)
+    $nugetConfigPath = Join-Path $workRoot 'NuGet.config'
+    @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="$escapedPackageDirectory" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+"@ | Set-Content -LiteralPath $nugetConfigPath -Encoding UTF8
+
+    $validProjectPath = Join-Path $validProjectDirectory 'ValidConsumer.csproj'
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NexusLabs.TUnit.Assertions" Version="$packageVersion" />
+    <PackageReference Include="TUnit" Version="$tunitVersion" />
+  </ItemGroup>
+</Project>
+"@ | Set-Content -LiteralPath $validProjectPath -Encoding UTF8
+
+    @'
+using NexusLabs.Framework;
+using NexusLabs.TUnit.Assertions;
+
+public sealed class PackageSmokeTests
+{
+    [Test]
+    public async Task Assertions_ReturnValuesAndErrors(
+        CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        TriedEx<int> success = 42;
+        TriedEx<int> failure = new ArgumentException("expected");
+
+        var value = await Assert.That(success)
+            .Succeeded()
+            .Because("The successful result should expose its value");
+        var error = await Assert.That(failure)
+            .Failed()
+            .With<ArgumentException>()
+            .Because("The failed result should expose its exception");
+
+        await Assert.That(value).IsEqualTo(42);
+        await Assert.That(error.Message).IsEqualTo("expected");
+    }
+}
+'@ | Set-Content `
+        -LiteralPath (Join-Path $validProjectDirectory 'PackageSmokeTests.cs') `
+        -Encoding UTF8
+
+    & dotnet restore $validProjectPath --configfile $nugetConfigPath
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw 'Restoring the valid package consumer failed.'
+    }
+
+    & dotnet run `
+        --project $validProjectPath `
+        --configuration Release `
+        --no-restore
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw 'Running the valid package consumer failed.'
+    }
+
+    $analyzerProjectPath =
+        Join-Path $analyzerProjectDirectory 'AnalyzerConsumer.csproj'
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>NLT0001</WarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NexusLabs.TUnit.Assertions" Version="$packageVersion" />
+    <PackageReference Include="TUnit" Version="$tunitVersion" />
+  </ItemGroup>
+</Project>
+"@ | Set-Content -LiteralPath $analyzerProjectPath -Encoding UTF8
+
+    @'
+using NexusLabs.Framework;
+
+public sealed class AnalyzerPackageSmokeTests
+{
+    [Test]
+    public async Task DirectMemberAssertion_IsRejected(
+        CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        TriedEx<int> result = 42;
+
+        await Assert.That(result.Success)
+            .IsTrue()
+            .Because("The package analyzer should reject this pattern");
+    }
+}
+'@ | Set-Content `
+        -LiteralPath (Join-Path $analyzerProjectDirectory 'AnalyzerPackageSmokeTests.cs') `
+        -Encoding UTF8
+
+    & dotnet restore $analyzerProjectPath --configfile $nugetConfigPath
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw 'Restoring the analyzer package consumer failed.'
+    }
+
+    $buildOutput = & dotnet build `
+        $analyzerProjectPath `
+        --configuration Release `
+        --no-restore `
+        2>&1 |
+        Out-String
+    $buildExitCode = $LASTEXITCODE
+
+    if ($buildExitCode -eq 0)
+    {
+        throw 'The analyzer consumer unexpectedly built without NLT0001.'
+    }
+
+    if (!$buildOutput.Contains('NLT0001', [StringComparison]::Ordinal))
+    {
+        throw "The analyzer consumer failed without reporting NLT0001:`n$buildOutput"
+    }
+}
+finally
+{
+    if (Test-Path -LiteralPath $workRoot)
+    {
+        Remove-Item -LiteralPath $workRoot -Recurse -Force
+    }
+}
+
+$global:LASTEXITCODE = 0

--- a/src/NexusLabs.TUnit.Assertions.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/NexusLabs.TUnit.Assertions.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/NexusLabs.TUnit.Assertions.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/NexusLabs.TUnit.Assertions.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,8 @@
+; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+NLT0001 | Usage    | Warning  | Assert TriedEx and TriedNullEx results directly with NexusLabs.TUnit.Assertions Succeeded() or Failed() instead of passing their Success, Value, or Error properties to TUnit Assert.That.

--- a/src/NexusLabs.TUnit.Assertions.Analyzers/DiagnosticDescriptors.cs
+++ b/src/NexusLabs.TUnit.Assertions.Analyzers/DiagnosticDescriptors.cs
@@ -1,0 +1,23 @@
+using Microsoft.CodeAnalysis;
+
+namespace NexusLabs.TUnit.Assertions.Analyzers;
+
+internal static class DiagnosticDescriptors
+{
+    public static readonly DiagnosticDescriptor AssertTriedResultDirectly = new(
+        id: "NLT0001",
+        title: "Assert Tried results directly",
+        messageFormat:
+            "Assert the Tried result directly instead of its '{0}' property; " +
+            "use `Assert.That(result).Succeeded()` for success/value assertions " +
+            "or `Assert.That(result).Failed()` for failure/error assertions",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description:
+            "TUnit assertions over TriedEx<T> and TriedNullEx<T> should assert the " +
+            "complete result. Succeeded() validates and returns the successful value; " +
+            "Failed() validates and returns the captured exception.",
+        helpLinkUri:
+            "https://github.com/ncosentino/NexusLabs.Framework/blob/master/docs/analyzers/NLT0001.md");
+}

--- a/src/NexusLabs.TUnit.Assertions.Analyzers/NexusLabs.TUnit.Assertions.Analyzers.csproj
+++ b/src/NexusLabs.TUnit.Assertions.Analyzers/NexusLabs.TUnit.Assertions.Analyzers.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Description>Roslyn analyzer guidance for NexusLabs.TUnit.Assertions. Reports direct TUnit assertions on TriedEx and TriedNullEx members so tests use the result-level Succeeded() and Failed() assertions.</Description>
+
+    <IsPackable>false</IsPackable>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <DevelopmentDependency>true</DevelopmentDependency>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="AnalyzerReleases.Shipped.md" />
+    <None Include="AnalyzerReleases.Unshipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
+</Project>

--- a/src/NexusLabs.TUnit.Assertions.Analyzers/TriedResultAssertionAnalyzer.cs
+++ b/src/NexusLabs.TUnit.Assertions.Analyzers/TriedResultAssertionAnalyzer.cs
@@ -1,0 +1,90 @@
+using System.Collections.Immutable;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace NexusLabs.TUnit.Assertions.Analyzers;
+
+/// <summary>
+/// Reports TUnit <c>Assert.That(...)</c> calls that assert a
+/// <c>TriedEx&lt;T&gt;</c> or <c>TriedNullEx&lt;T&gt;</c> member instead of
+/// asserting the complete result with <c>Succeeded()</c> or <c>Failed()</c>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class TriedResultAssertionAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(DiagnosticDescriptors.AssertTriedResultDirectly);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        if (!IsTUnitAssertThat(invocation.TargetMethod))
+        {
+            return;
+        }
+
+        var assertedValue = invocation.Arguments
+            .FirstOrDefault(argument => argument.Parameter?.Ordinal == 0)
+            ?.Value;
+        assertedValue = UnwrapConversion(assertedValue);
+
+        if (assertedValue is not IPropertyReferenceOperation propertyReference ||
+            !IsTriedResultProperty(propertyReference.Property))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.AssertTriedResultDirectly,
+            propertyReference.Syntax.GetLocation(),
+            propertyReference.Property.Name));
+    }
+
+    private static bool IsTUnitAssertThat(IMethodSymbol method)
+    {
+        if (method.Name != "That" ||
+            method.ContainingType?.Name != "Assert")
+        {
+            return false;
+        }
+
+        return method.ContainingNamespace?.ToDisplayString() == "TUnit.Assertions";
+    }
+
+    private static bool IsTriedResultProperty(IPropertySymbol property)
+    {
+        if (property.Name is not ("Success" or "Value" or "Error"))
+        {
+            return false;
+        }
+
+        var containingType = property.ContainingType;
+        if (containingType.Name is not ("TriedEx" or "TriedNullEx"))
+        {
+            return false;
+        }
+
+        return containingType.ContainingNamespace?.ToDisplayString() ==
+            "NexusLabs.Framework";
+    }
+
+    private static IOperation? UnwrapConversion(IOperation? operation)
+    {
+        while (operation is IConversionOperation conversion)
+        {
+            operation = conversion.Operand;
+        }
+
+        return operation;
+    }
+}

--- a/src/NexusLabs.TUnit.Assertions/NexusLabs.TUnit.Assertions.csproj
+++ b/src/NexusLabs.TUnit.Assertions/NexusLabs.TUnit.Assertions.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>TUnit assertions for NexusLabs.Framework TriedEx and TriedNullEx results. Assert the complete result with Succeeded() or Failed(), receive the successful value or captured exception from await, and get bundled analyzer guidance for direct member assertions.</Description>
+    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/master/CHANGELOG.md</PackageReleaseNotes>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NexusLabs.Framework\NexusLabs.Framework.csproj" />
+    <ProjectReference Include="..\NexusLabs.TUnit.Assertions.Analyzers\NexusLabs.TUnit.Assertions.Analyzers.csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\NexusLabs.Testing.Assertions.Shared\*.cs"
+             Link="Shared\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit.Assertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\NexusLabs.TUnit.Assertions.Analyzers\bin\$(Configuration)\netstandard2.0\NexusLabs.TUnit.Assertions.Analyzers.dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs/netstandard2.0"
+          Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/NexusLabs.TUnit.Assertions/TriedAssertionEvaluationException.cs
+++ b/src/NexusLabs.TUnit.Assertions/TriedAssertionEvaluationException.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace NexusLabs.TUnit.Assertions;
+
+internal sealed class TriedAssertionEvaluationException : Exception
+{
+    public TriedAssertionEvaluationException()
+    {
+    }
+
+    public TriedAssertionEvaluationException(string message)
+        : base(message)
+    {
+    }
+
+    public TriedAssertionEvaluationException(
+        string message,
+        Exception? actualError)
+        : base(message, actualError)
+    {
+        ActualError = actualError;
+    }
+
+    public Exception? ActualError { get; }
+}

--- a/src/NexusLabs.TUnit.Assertions/TriedAssertionExtensions.cs
+++ b/src/NexusLabs.TUnit.Assertions/TriedAssertionExtensions.cs
@@ -1,0 +1,68 @@
+using NexusLabs.Framework;
+
+using TUnit.Assertions.Core;
+
+namespace NexusLabs.TUnit.Assertions;
+
+/// <summary>
+/// TUnit assertion extensions for <see cref="TriedEx{T}"/> and
+/// <see cref="TriedNullEx{T}"/> results.
+/// </summary>
+public static class TriedAssertionExtensions
+{
+    /// <summary>
+    /// Asserts that <paramref name="source"/> contains a successful
+    /// <see cref="TriedEx{T}"/> and returns its value when awaited.
+    /// </summary>
+    /// <typeparam name="T">The successful value type.</typeparam>
+    /// <param name="source">The TUnit assertion source.</param>
+    /// <returns>An awaitable assertion that produces the successful value.</returns>
+    public static TriedSucceededAssertion<T> Succeeded<T>(
+        this IAssertionSource<TriedEx<T>> source)
+    {
+        source.Context.ExpressionBuilder.Append(".Succeeded()");
+        return new TriedSucceededAssertion<T>(source.Context);
+    }
+
+    /// <summary>
+    /// Asserts that <paramref name="source"/> contains a successful
+    /// <see cref="TriedNullEx{T}"/> and returns its possibly-null value when awaited.
+    /// </summary>
+    /// <typeparam name="T">The successful value type.</typeparam>
+    /// <param name="source">The TUnit assertion source.</param>
+    /// <returns>An awaitable assertion that produces the successful value.</returns>
+    public static TriedNullSucceededAssertion<T> Succeeded<T>(
+        this IAssertionSource<TriedNullEx<T?>> source)
+    {
+        source.Context.ExpressionBuilder.Append(".Succeeded()");
+        return new TriedNullSucceededAssertion<T>(source.Context);
+    }
+
+    /// <summary>
+    /// Asserts that <paramref name="source"/> contains a failed
+    /// <see cref="TriedEx{T}"/> and returns its original exception when awaited.
+    /// </summary>
+    /// <typeparam name="T">The result value type.</typeparam>
+    /// <param name="source">The TUnit assertion source.</param>
+    /// <returns>An awaitable assertion that produces the captured exception.</returns>
+    public static TriedFailedAssertion<T> Failed<T>(
+        this IAssertionSource<TriedEx<T>> source)
+    {
+        source.Context.ExpressionBuilder.Append(".Failed()");
+        return new TriedFailedAssertion<T>(source.Context);
+    }
+
+    /// <summary>
+    /// Asserts that <paramref name="source"/> contains a failed
+    /// <see cref="TriedNullEx{T}"/> and returns its original exception when awaited.
+    /// </summary>
+    /// <typeparam name="T">The result value type.</typeparam>
+    /// <param name="source">The TUnit assertion source.</param>
+    /// <returns>An awaitable assertion that produces the captured exception.</returns>
+    public static TriedFailedAssertion<T> Failed<T>(
+        this IAssertionSource<TriedNullEx<T?>> source)
+    {
+        source.Context.ExpressionBuilder.Append(".Failed()");
+        return new TriedFailedAssertion<T>(source.Context);
+    }
+}

--- a/src/NexusLabs.TUnit.Assertions/TriedAssertionMapping.cs
+++ b/src/NexusLabs.TUnit.Assertions/TriedAssertionMapping.cs
@@ -1,0 +1,83 @@
+using System;
+
+using NexusLabs.Framework;
+using NexusLabs.Testing.Assertions;
+
+namespace NexusLabs.TUnit.Assertions;
+
+internal static class TriedAssertionMapping
+{
+    public static T GetSuccessfulValue<T>(TriedEx<T> actual)
+    {
+        var evaluation = TriedAssertionEvaluator.Evaluate(actual);
+        if (evaluation.Success)
+        {
+            return evaluation.Value!;
+        }
+
+        var error = evaluation.Error!;
+        throw new TriedAssertionEvaluationException(
+            $"the result failed with {error.GetType().Name}: {error.Message}",
+            error);
+    }
+
+    public static T? GetSuccessfulValue<T>(TriedNullEx<T?> actual)
+    {
+        var evaluation = TriedAssertionEvaluator.Evaluate(actual);
+        if (evaluation.Success)
+        {
+            return evaluation.Value;
+        }
+
+        var error = evaluation.Error!;
+        throw new TriedAssertionEvaluationException(
+            $"the result failed with {error.GetType().Name}: {error.Message}",
+            error);
+    }
+
+    public static Exception GetFailure<T>(TriedEx<T> actual)
+    {
+        var evaluation = TriedAssertionEvaluator.Evaluate(actual);
+        if (!evaluation.Success)
+        {
+            return evaluation.Error!;
+        }
+
+        throw new TriedAssertionEvaluationException(
+            "the result succeeded",
+            actualError: null);
+    }
+
+    public static Exception GetFailure<T>(TriedNullEx<T?> actual)
+    {
+        var evaluation = TriedAssertionEvaluator.Evaluate(actual);
+        if (!evaluation.Success)
+        {
+            return evaluation.Error!;
+        }
+
+        throw new TriedAssertionEvaluationException(
+            "the result succeeded",
+            actualError: null);
+    }
+
+    public static TException GetFailure<TException>(Exception? error)
+        where TException : Exception
+    {
+        if (error is null)
+        {
+            throw new TriedAssertionEvaluationException(
+                "the result did not contain an exception",
+                actualError: null);
+        }
+
+        if (error is TException typedError)
+        {
+            return typedError;
+        }
+
+        throw new TriedAssertionEvaluationException(
+            $"the result failed with {error.GetType().Name} instead of {typeof(TException).Name}",
+            error);
+    }
+}

--- a/src/NexusLabs.TUnit.Assertions/TriedAssertionResult.cs
+++ b/src/NexusLabs.TUnit.Assertions/TriedAssertionResult.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+
+using TUnit.Assertions.Core;
+
+namespace NexusLabs.TUnit.Assertions;
+
+internal static class TriedAssertionResult
+{
+    public static Task<AssertionResult> FromException(Exception? exception)
+    {
+        if (exception is null)
+        {
+            return Task.FromResult(AssertionResult.Passed);
+        }
+
+        if (exception is TriedAssertionEvaluationException evaluationException)
+        {
+            return Task.FromResult(AssertionResult.Failed(
+                evaluationException.Message,
+                evaluationException.ActualError));
+        }
+
+        return Task.FromResult(AssertionResult.Failed(
+            $"evaluating the asserted result threw {exception.GetType().Name}: {exception.Message}",
+            exception));
+    }
+}

--- a/src/NexusLabs.TUnit.Assertions/TriedFailedAssertion.cs
+++ b/src/NexusLabs.TUnit.Assertions/TriedFailedAssertion.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using NexusLabs.Framework;
+
+using TUnit.Assertions.Core;
+
+namespace NexusLabs.TUnit.Assertions;
+
+/// <summary>
+/// TUnit assertion that requires a Tried result to have failed and returns its
+/// original exception when awaited.
+/// </summary>
+/// <typeparam name="T">The result value type.</typeparam>
+public sealed class TriedFailedAssertion<T> : Assertion<Exception>
+{
+    internal TriedFailedAssertion(AssertionContext<TriedEx<T>> context)
+        : base(context.Map(TriedAssertionMapping.GetFailure))
+    {
+    }
+
+    internal TriedFailedAssertion(AssertionContext<TriedNullEx<T?>> context)
+        : base(context.Map(TriedAssertionMapping.GetFailure))
+    {
+    }
+
+    /// <summary>
+    /// Adds context explaining why the result is expected to have failed.
+    /// </summary>
+    /// <param name="message">The reason displayed when the assertion fails.</param>
+    /// <returns>This assertion for fluent chaining.</returns>
+    public new TriedFailedAssertion<T> Because(string message)
+    {
+        base.Because(message);
+        return this;
+    }
+
+    /// <summary>
+    /// Requires the captured exception to be assignable to
+    /// <typeparamref name="TException"/> and returns it strongly typed when awaited.
+    /// </summary>
+    /// <typeparam name="TException">The expected exception type.</typeparam>
+    /// <returns>An awaitable assertion that produces the typed exception.</returns>
+    public TriedFailedWithAssertion<TException> With<TException>()
+        where TException : Exception
+    {
+        AppendExpression($".With<{typeof(TException).Name}>()");
+        return new TriedFailedWithAssertion<TException>(
+            Context.Map(TriedAssertionMapping.GetFailure<TException>));
+    }
+
+    /// <summary>
+    /// Returns an awaiter that produces the captured exception.
+    /// </summary>
+    /// <returns>An awaiter for the assertion result.</returns>
+    public new TaskAwaiter<Exception> GetAwaiter() => GetErrorAsync().GetAwaiter();
+
+    protected override Task<AssertionResult> CheckAsync(
+        EvaluationMetadata<Exception> metadata) =>
+        TriedAssertionResult.FromException(metadata.Exception);
+
+    protected override string GetExpectation() => "the result to have failed";
+
+#pragma warning disable NLF0020 // The awaiter protocol has no CancellationToken parameter.
+    private async Task<Exception> GetErrorAsync() => (await AssertAsync())!;
+#pragma warning restore NLF0020
+}

--- a/src/NexusLabs.TUnit.Assertions/TriedFailedWithAssertion.cs
+++ b/src/NexusLabs.TUnit.Assertions/TriedFailedWithAssertion.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using TUnit.Assertions.Core;
+
+namespace NexusLabs.TUnit.Assertions;
+
+/// <summary>
+/// TUnit assertion that requires a Tried result to contain an exception
+/// assignable to <typeparamref name="TException"/>.
+/// </summary>
+/// <typeparam name="TException">The expected exception type.</typeparam>
+public sealed class TriedFailedWithAssertion<TException> : Assertion<TException>
+    where TException : Exception
+{
+    internal TriedFailedWithAssertion(AssertionContext<TException> context)
+        : base(context)
+    {
+    }
+
+    /// <summary>
+    /// Adds context explaining why the result is expected to contain this
+    /// exception type.
+    /// </summary>
+    /// <param name="message">The reason displayed when the assertion fails.</param>
+    /// <returns>This assertion for fluent chaining.</returns>
+    public new TriedFailedWithAssertion<TException> Because(string message)
+    {
+        base.Because(message);
+        return this;
+    }
+
+    /// <summary>
+    /// Returns an awaiter that produces the captured typed exception.
+    /// </summary>
+    /// <returns>An awaiter for the assertion result.</returns>
+    public new TaskAwaiter<TException> GetAwaiter() => GetErrorAsync().GetAwaiter();
+
+    protected override Task<AssertionResult> CheckAsync(
+        EvaluationMetadata<TException> metadata) =>
+        TriedAssertionResult.FromException(metadata.Exception);
+
+    protected override string GetExpectation() =>
+        $"the result to have failed with {typeof(TException).Name}";
+
+#pragma warning disable NLF0020 // The awaiter protocol has no CancellationToken parameter.
+    private async Task<TException> GetErrorAsync() => (await AssertAsync())!;
+#pragma warning restore NLF0020
+}

--- a/src/NexusLabs.TUnit.Assertions/TriedNullSucceededAssertion.cs
+++ b/src/NexusLabs.TUnit.Assertions/TriedNullSucceededAssertion.cs
@@ -1,0 +1,49 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using NexusLabs.Framework;
+
+using TUnit.Assertions.Core;
+
+namespace NexusLabs.TUnit.Assertions;
+
+/// <summary>
+/// TUnit assertion that requires a <see cref="TriedNullEx{T}"/> to be
+/// successful and returns its possibly-null value when awaited.
+/// </summary>
+/// <typeparam name="T">The successful value type.</typeparam>
+public sealed class TriedNullSucceededAssertion<T> : Assertion<T?>
+{
+    internal TriedNullSucceededAssertion(AssertionContext<TriedNullEx<T?>> context)
+        : base(context.Map<T?>(
+            actual => TriedAssertionMapping.GetSuccessfulValue(actual)))
+    {
+    }
+
+    /// <summary>
+    /// Adds context explaining why the result is expected to be successful.
+    /// </summary>
+    /// <param name="message">The reason displayed when the assertion fails.</param>
+    /// <returns>This assertion for fluent chaining.</returns>
+    public new TriedNullSucceededAssertion<T> Because(string message)
+    {
+        base.Because(message);
+        return this;
+    }
+
+    /// <summary>
+    /// Returns an awaiter that produces the possibly-null successful value.
+    /// </summary>
+    /// <returns>An awaiter for the assertion result.</returns>
+    public new TaskAwaiter<T?> GetAwaiter() => GetValueAsync().GetAwaiter();
+
+    protected override Task<AssertionResult> CheckAsync(
+        EvaluationMetadata<T?> metadata) =>
+        TriedAssertionResult.FromException(metadata.Exception);
+
+    protected override string GetExpectation() => "the result to have succeeded";
+
+#pragma warning disable NLF0020 // The awaiter protocol has no CancellationToken parameter.
+    private async Task<T?> GetValueAsync() => await AssertAsync();
+#pragma warning restore NLF0020
+}

--- a/src/NexusLabs.TUnit.Assertions/TriedSucceededAssertion.cs
+++ b/src/NexusLabs.TUnit.Assertions/TriedSucceededAssertion.cs
@@ -1,0 +1,48 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+using NexusLabs.Framework;
+
+using TUnit.Assertions.Core;
+
+namespace NexusLabs.TUnit.Assertions;
+
+/// <summary>
+/// TUnit assertion that requires a <see cref="TriedEx{T}"/> to be successful
+/// and returns its non-null value when awaited.
+/// </summary>
+/// <typeparam name="T">The successful value type.</typeparam>
+public sealed class TriedSucceededAssertion<T> : Assertion<T>
+{
+    internal TriedSucceededAssertion(AssertionContext<TriedEx<T>> context)
+        : base(context.Map(TriedAssertionMapping.GetSuccessfulValue))
+    {
+    }
+
+    /// <summary>
+    /// Adds context explaining why the result is expected to be successful.
+    /// </summary>
+    /// <param name="message">The reason displayed when the assertion fails.</param>
+    /// <returns>This assertion for fluent chaining.</returns>
+    public new TriedSucceededAssertion<T> Because(string message)
+    {
+        base.Because(message);
+        return this;
+    }
+
+    /// <summary>
+    /// Returns an awaiter that produces the successful value.
+    /// </summary>
+    /// <returns>An awaiter for the assertion result.</returns>
+    public new TaskAwaiter<T> GetAwaiter() => GetValueAsync().GetAwaiter();
+
+    protected override Task<AssertionResult> CheckAsync(
+        EvaluationMetadata<T> metadata) =>
+        TriedAssertionResult.FromException(metadata.Exception);
+
+    protected override string GetExpectation() => "the result to have succeeded";
+
+#pragma warning disable NLF0020 // The awaiter protocol has no CancellationToken parameter.
+    private async Task<T> GetValueAsync() => (await AssertAsync())!;
+#pragma warning restore NLF0020
+}

--- a/src/NexusLabs.Testing.Assertions.Shared/TriedAssertionEvaluation.cs
+++ b/src/NexusLabs.Testing.Assertions.Shared/TriedAssertionEvaluation.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace NexusLabs.Testing.Assertions;
+
+internal readonly record struct TriedAssertionEvaluation<T>(
+    bool Success,
+    T? Value,
+    Exception? Error);

--- a/src/NexusLabs.Testing.Assertions.Shared/TriedAssertionEvaluator.cs
+++ b/src/NexusLabs.Testing.Assertions.Shared/TriedAssertionEvaluator.cs
@@ -1,0 +1,29 @@
+using NexusLabs.Framework;
+
+namespace NexusLabs.Testing.Assertions;
+
+internal static class TriedAssertionEvaluator
+{
+    public static TriedAssertionEvaluation<T> Evaluate<T>(TriedEx<T> actual) =>
+        actual.Match(
+            value => new TriedAssertionEvaluation<T>(
+                Success: true,
+                Value: value,
+                Error: null),
+            error => new TriedAssertionEvaluation<T>(
+                Success: false,
+                Value: default,
+                Error: error));
+
+    public static TriedAssertionEvaluation<T?> Evaluate<T>(
+        TriedNullEx<T?> actual) =>
+        actual.Match(
+            value => new TriedAssertionEvaluation<T?>(
+                Success: true,
+                Value: value,
+                Error: null),
+            error => new TriedAssertionEvaluation<T?>(
+                Success: false,
+                Value: default,
+                Error: error));
+}

--- a/src/NexusLabs.Xunit.Assertions/AssertAugmentations.cs
+++ b/src/NexusLabs.Xunit.Assertions/AssertAugmentations.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text.Json;
 
 using NexusLabs.Framework;
+using NexusLabs.Testing.Assertions;
 
 using Xunit;
 using Xunit.Sdk;
@@ -173,26 +174,25 @@ public static class AssertAugmentations
             where TException : Exception
 #pragma warning restore NLF0015
         {
-            TException? actualException = null;
-            actual.Match<T>(
-                _ => throw new XunitException(
+            var evaluation = TriedAssertionEvaluator.Evaluate(actual);
+            if (evaluation.Success)
+            {
+                throw new XunitException(
                     $"{message}\r\n" +
-                    $"The {nameof(TriedEx<T>)} instance was successful and was expected to fail with {typeof(TException)}."),
-                error =>
-                {
-                    if (!error.GetType().IsAssignableTo(typeof(TException)))
-                    {
-                        throw new XunitException(
-                            $"{message}\r\n" +
-                            $"The error type '{error.GetType()}' was not of " +
-                            $"type {typeof(TException)}. See inner exception for details.",
-                            error);
-                    }
+                    $"The {nameof(TriedEx<T>)} instance was successful and was expected to fail with {typeof(TException)}.");
+            }
 
-                    actualException = (TException)error;
-                    return default!;
-                });
-            return actualException!;
+            var error = evaluation.Error!;
+            if (error is not TException actualException)
+            {
+                throw new XunitException(
+                    $"{message}\r\n" +
+                    $"The error type '{error.GetType()}' was not of " +
+                    $"type {typeof(TException)}. See inner exception for details.",
+                    error);
+            }
+
+            return actualException;
         }
 
         /// <summary>
@@ -206,26 +206,25 @@ public static class AssertAugmentations
             where TException : Exception
 #pragma warning restore NLF0015
         {
-            TException? actualException = null;
-            actual.Match<T?>(
-                _ => throw new XunitException(
+            var evaluation = TriedAssertionEvaluator.Evaluate(actual);
+            if (evaluation.Success)
+            {
+                throw new XunitException(
                     $"{message}\r\n" +
-                    $"The {nameof(TriedNullEx<T?>)} instance was successful and was expected to fail with {typeof(TException)}."),
-                error =>
-                {
-                    if (!error.GetType().IsAssignableTo(typeof(TException)))
-                    {
-                        throw new XunitException(
-                            $"{message}\r\n" +
-                            $"The error type '{error.GetType()}' was not of " +
-                            $"type {typeof(TException)}. See inner exception for details.",
-                            error);
-                    }
+                    $"The {nameof(TriedNullEx<T?>)} instance was successful and was expected to fail with {typeof(TException)}.");
+            }
 
-                    actualException = (TException)error;
-                    return default!;
-                });
-            return actualException!;
+            var error = evaluation.Error!;
+            if (error is not TException actualException)
+            {
+                throw new XunitException(
+                    $"{message}\r\n" +
+                    $"The error type '{error.GetType()}' was not of " +
+                    $"type {typeof(TException)}. See inner exception for details.",
+                    error);
+            }
+
+            return actualException;
         }
 
         /// <summary>
@@ -239,13 +238,14 @@ public static class AssertAugmentations
             string message)
 #pragma warning restore NLF0015
         {
+            var evaluation = TriedAssertionEvaluator.Evaluate(actual);
             True(
-                actual.Success,
+                evaluation.Success,
                 () =>
                     $"{message}\r\n" +
                     $"The error was not null:\r\n" +
-                    $"{ExceptionHelper.BuildExceptionMessage(actual)}");
-            return actual;
+                    $"{ExceptionHelper.BuildExceptionMessage(evaluation.Error)}");
+            return evaluation.Value!;
         }
 
         /// <summary>
@@ -258,13 +258,14 @@ public static class AssertAugmentations
             string message)
 #pragma warning restore NLF0015
         {
+            var evaluation = TriedAssertionEvaluator.Evaluate(actual);
             True(
-                actual.Success,
+                evaluation.Success,
                 () =>
                     $"{message}\r\n" +
                     $"The error was not null:\r\n" +
-                    $"{ExceptionHelper.BuildExceptionMessage(actual)}");
-            return actual;
+                    $"{ExceptionHelper.BuildExceptionMessage(evaluation.Error)}");
+            return evaluation.Value;
         }
 
         /// <summary>

--- a/src/NexusLabs.Xunit.Assertions/NexusLabs.Xunit.Assertions.csproj
+++ b/src/NexusLabs.Xunit.Assertions/NexusLabs.Xunit.Assertions.csproj
@@ -11,6 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\NexusLabs.Testing.Assertions.Shared\*.cs"
+             Link="Shared\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="xunit.v3.assert" />
     <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>

--- a/tests/NexusLabs.Xunit.Assertions.Tests/AssertAugmentationsTests.cs
+++ b/tests/NexusLabs.Xunit.Assertions.Tests/AssertAugmentationsTests.cs
@@ -102,6 +102,43 @@ public sealed class AssertAugmentationsTests
     }
 
     [Fact]
+    public void TrySucceeded_SuccessfulTriedNullEx_ReturnsNull()
+    {
+        TriedNullEx<string?> tried = (string?)null;
+
+        var value = Assert.TrySucceeded(tried, "should not fail");
+
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryFailed_FailedTriedNullEx_ReturnsTheException()
+    {
+        var original = new InvalidOperationException("the original");
+        TriedNullEx<string?> tried = original;
+
+        var captured = Assert.TryFailed<string, InvalidOperationException>(
+            tried,
+            "context");
+
+        Assert.Same(original, captured);
+    }
+
+    [Fact]
+    public void TryFailed_WrongExceptionType_PreservesOriginalAsInnerException()
+    {
+        var original = new InvalidOperationException("the original");
+        TriedEx<int> tried = original;
+
+        var thrown = Assert.Throws<XunitException>(() =>
+            Assert.TryFailed<int, ArgumentException>(
+                tried,
+                "expected argument failure"));
+
+        Assert.Same(original, thrown.InnerException);
+    }
+
+    [Fact]
     public void NotNull_NullValue_ThrowsWithCallerMessage()
     {
         string? value = null;

--- a/tests/TUnit/Directory.Build.props
+++ b/tests/TUnit/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+
+  <PropertyGroup>
+    <NexusLabsTestFramework>TUnit</NexusLabsTestFramework>
+  </PropertyGroup>
+
+  <Import Project="..\..\Directory.Build.props" />
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/TUnit/NexusLabs.TUnit.Assertions.Tests/AnalyzerVerifier.cs
+++ b/tests/TUnit/NexusLabs.TUnit.Assertions.Tests/AnalyzerVerifier.cs
@@ -1,0 +1,41 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+using NexusLabs.CodeAnalysis.Testing.TUnit;
+
+namespace NexusLabs.TUnit.Assertions.Tests;
+
+internal static class AnalyzerVerifier<TAnalyzer>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+{
+    public static Task VerifyAsync(
+        string source,
+        CancellationToken cancellationToken) =>
+        VerifyAsync(source, [], cancellationToken);
+
+    public static Task VerifyAsync(
+        string source,
+        DiagnosticResult expected,
+        CancellationToken cancellationToken) =>
+        VerifyAsync(source, [expected], cancellationToken);
+
+    private static async Task VerifyAsync(
+        string source,
+        DiagnosticResult[] expected,
+        CancellationToken cancellationToken)
+    {
+        var test = new CSharpAnalyzerTest<TAnalyzer, TUnitVerifier>
+        {
+            TestCode = source,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90,
+        };
+
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync(cancellationToken);
+    }
+}

--- a/tests/TUnit/NexusLabs.TUnit.Assertions.Tests/NexusLabs.TUnit.Assertions.Tests.csproj
+++ b/tests/TUnit/NexusLabs.TUnit.Assertions.Tests/NexusLabs.TUnit.Assertions.Tests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NexusLabs.CodeAnalysis.Testing.TUnit\NexusLabs.CodeAnalysis.Testing.TUnit.csproj" />
+    <ProjectReference Include="..\..\..\src\NexusLabs.TUnit.Assertions\NexusLabs.TUnit.Assertions.csproj" />
+    <ProjectReference Include="..\..\..\src\NexusLabs.TUnit.Assertions.Analyzers\NexusLabs.TUnit.Assertions.Analyzers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/TUnit/NexusLabs.TUnit.Assertions.Tests/TriedAssertionTests.cs
+++ b/tests/TUnit/NexusLabs.TUnit.Assertions.Tests/TriedAssertionTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NexusLabs.Framework;
+
+using TUnit.Assertions.Exceptions;
+
+namespace NexusLabs.TUnit.Assertions.Tests;
+
+public sealed class TriedAssertionTests
+{
+    [Test]
+    public async Task Succeeded_TriedEx_ReturnsOriginalValue(
+        CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        var expected = new object();
+        TriedEx<object> result = expected;
+
+        var actual = await Assert.That(result)
+            .Succeeded()
+            .Because("The result should expose its successful value");
+
+        await Assert.That(ReferenceEquals(expected, actual))
+            .IsTrue()
+            .Because("Succeeded should preserve the original value instance");
+    }
+
+    [Test]
+    public async Task Succeeded_TriedNullEx_ReturnsNull(
+        CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        TriedNullEx<string?> result = (string?)null;
+
+        var actual = await Assert.That(result)
+            .Succeeded()
+            .Because("A null value is valid for TriedNullEx");
+
+        await Assert.That(actual).IsNull();
+    }
+
+    [Test]
+    public async Task Succeeded_FailedResult_IncludesReasonAndOriginalError(
+        CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        var original = new InvalidOperationException("original failure");
+        TriedEx<int> result = original;
+
+        Func<Task> action = async () =>
+        {
+            _ = await Assert.That(result)
+                .Succeeded()
+                .Because("The operation should have succeeded");
+        };
+
+        var exception = (await Assert.That(action).Throws<AssertionException>())!;
+
+        await Assert.That(exception.Message)
+            .Contains("The operation should have succeeded");
+        await Assert.That(exception.Message)
+            .Contains(nameof(InvalidOperationException));
+        await Assert.That(exception.Message)
+            .Contains(original.Message);
+        await Assert.That(ReferenceEquals(original, exception.InnerException))
+            .IsTrue()
+            .Because("The assertion should preserve the captured exception");
+    }
+
+    [Test]
+    public async Task Failed_ReturnsOriginalException(
+        CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        var original = new InvalidOperationException("expected failure");
+        TriedEx<int> result = original;
+
+        var actual = await Assert.That(result)
+            .Failed()
+            .Because("The result should have failed");
+
+        await Assert.That(ReferenceEquals(original, actual))
+            .IsTrue()
+            .Because("Failed should preserve the original exception instance");
+    }
+
+    [Test]
+    public async Task FailedWith_AssignableException_ReturnsOriginalException(
+        CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        var original = new ArgumentNullException("value");
+        TriedNullEx<string?> result = original;
+
+        var actual = await Assert.That(result)
+            .Failed()
+            .With<ArgumentException>()
+            .Because("The result should contain a validation failure");
+
+        await Assert.That(ReferenceEquals(original, actual))
+            .IsTrue()
+            .Because("Typed failure assertions should preserve exception identity");
+    }
+
+    [Test]
+    public async Task Failed_SuccessfulResult_IncludesReason(
+        CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        TriedEx<int> result = 42;
+
+        Func<Task> action = async () =>
+        {
+            _ = await Assert.That(result)
+                .Failed()
+                .Because("The operation should have failed");
+        };
+
+        var exception = (await Assert.That(action).Throws<AssertionException>())!;
+
+        await Assert.That(exception.Message)
+            .Contains("The operation should have failed");
+        await Assert.That(exception.Message)
+            .Contains("the result succeeded");
+    }
+
+    [Test]
+    public async Task FailedWith_WrongExceptionType_ReportsBothTypes(
+        CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        var original = new InvalidOperationException("wrong failure");
+        TriedEx<int> result = original;
+
+        Func<Task> action = async () =>
+        {
+            _ = await Assert.That(result)
+                .Failed()
+                .With<ArgumentException>()
+                .Because("The result should contain an argument failure");
+        };
+
+        var exception = (await Assert.That(action).Throws<AssertionException>())!;
+
+        await Assert.That(exception.Message)
+            .Contains(nameof(InvalidOperationException));
+        await Assert.That(exception.Message)
+            .Contains(nameof(ArgumentException));
+        await Assert.That(ReferenceEquals(original, exception.InnerException))
+            .IsTrue()
+            .Because("The assertion should preserve the actual captured exception");
+    }
+}

--- a/tests/TUnit/NexusLabs.TUnit.Assertions.Tests/TriedResultAssertionAnalyzerTests.cs
+++ b/tests/TUnit/NexusLabs.TUnit.Assertions.Tests/TriedResultAssertionAnalyzerTests.cs
@@ -1,0 +1,242 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+
+using NexusLabs.TUnit.Assertions.Analyzers;
+
+namespace NexusLabs.TUnit.Assertions.Tests;
+
+public sealed class TriedResultAssertionAnalyzerTests
+{
+    [Test]
+    [Arguments("TriedEx", "Success")]
+    [Arguments("TriedEx", "Value")]
+    [Arguments("TriedEx", "Error")]
+    [Arguments("TriedNullEx", "Success")]
+    [Arguments("TriedNullEx", "Value")]
+    [Arguments("TriedNullEx", "Error")]
+    public async Task AssertThat_TriedResultMember_ReportsDiagnostic(
+        string resultType,
+        string propertyName,
+        CancellationToken cancellationToken)
+    {
+        var source =
+            $$"""
+            using NexusLabs.Framework;
+            using TUnit.Assertions;
+
+            namespace Test
+            {
+                public sealed class TestClass
+                {
+                    public void TestMethod()
+                    {
+                        {{resultType}}<string> result = default;
+                        Assert.That({|#0:result.{{propertyName}}|});
+                    }
+                }
+            }
+
+            namespace NexusLabs.Framework
+            {
+                public readonly struct TriedEx<T>
+                {
+                    public bool Success => true;
+                    public T Value => default!;
+                    public System.Exception Error => null!;
+                }
+
+                public readonly struct TriedNullEx<T>
+                {
+                    public bool Success => true;
+                    public T? Value => default;
+                    public System.Exception Error => null!;
+                }
+            }
+
+            namespace TUnit.Assertions
+            {
+                public static class Assert
+                {
+                    public static void That<T>(T value)
+                    {
+                    }
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult("NLT0001", DiagnosticSeverity.Warning)
+            .WithLocation(0)
+            .WithArguments(propertyName);
+
+        await AnalyzerVerifier<TriedResultAssertionAnalyzer>.VerifyAsync(
+            source,
+            expected,
+            cancellationToken);
+    }
+
+    [Test]
+    public async Task AssertThat_CompleteTriedResult_NoDiagnostic(
+        CancellationToken cancellationToken)
+    {
+        var source =
+            """
+            using NexusLabs.Framework;
+            using TUnit.Assertions;
+
+            namespace Test
+            {
+                public sealed class TestClass
+                {
+                    public void TestMethod()
+                    {
+                        TriedEx<string> result = default;
+                        Assert.That(result);
+                    }
+                }
+            }
+
+            namespace NexusLabs.Framework
+            {
+                public readonly struct TriedEx<T>
+                {
+                    public bool Success => true;
+                }
+            }
+
+            namespace TUnit.Assertions
+            {
+                public static class Assert
+                {
+                    public static void That<T>(T value)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await AnalyzerVerifier<TriedResultAssertionAnalyzer>.VerifyAsync(
+            source,
+            cancellationToken);
+    }
+
+    [Test]
+    public async Task NonTUnitAssert_TriedResultMember_NoDiagnostic(
+        CancellationToken cancellationToken)
+    {
+        var source =
+            """
+            using NexusLabs.Framework;
+
+            namespace Test
+            {
+                public sealed class TestClass
+                {
+                    public void TestMethod()
+                    {
+                        TriedEx<string> result = default;
+                        Assert.That(result.Success);
+                    }
+                }
+
+                public static class Assert
+                {
+                    public static void That<T>(T value)
+                    {
+                    }
+                }
+            }
+
+            namespace NexusLabs.Framework
+            {
+                public readonly struct TriedEx<T>
+                {
+                    public bool Success => true;
+                }
+            }
+            """;
+
+        await AnalyzerVerifier<TriedResultAssertionAnalyzer>.VerifyAsync(
+            source,
+            cancellationToken);
+    }
+
+    [Test]
+    public async Task TUnitAssert_LookalikeResult_NoDiagnostic(
+        CancellationToken cancellationToken)
+    {
+        var source =
+            """
+            using TUnit.Assertions;
+
+            namespace Test
+            {
+                public sealed class TestClass
+                {
+                    public void TestMethod()
+                    {
+                        TriedEx<string> result = default;
+                        Assert.That(result.Success);
+                    }
+                }
+
+                public readonly struct TriedEx<T>
+                {
+                    public bool Success => true;
+                }
+            }
+
+            namespace TUnit.Assertions
+            {
+                public static class Assert
+                {
+                    public static void That<T>(T value)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await AnalyzerVerifier<TriedResultAssertionAnalyzer>.VerifyAsync(
+            source,
+            cancellationToken);
+    }
+
+    [Test]
+    public async Task GuardedMemberAccess_OutsideAssertThat_NoDiagnostic(
+        CancellationToken cancellationToken)
+    {
+        var source =
+            """
+            using NexusLabs.Framework;
+
+            namespace Test
+            {
+                public sealed class TestClass
+                {
+                    public string? TestMethod(TriedEx<string> result)
+                    {
+                        return result.Success
+                            ? result.Value
+                            : null;
+                    }
+                }
+            }
+
+            namespace NexusLabs.Framework
+            {
+                public readonly struct TriedEx<T>
+                {
+                    public bool Success => true;
+                    public T Value => default!;
+                }
+            }
+            """;
+
+        await AnalyzerVerifier<TriedResultAssertionAnalyzer>.VerifyAsync(
+            source,
+            cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary

- add `NexusLabs.TUnit.Assertions` with native fluent assertions for
  `TriedEx<T>` and `TriedNullEx<T>`
- return successful values from `Succeeded()` and original exceptions from
  `Failed()` / `Failed().With<TException>()`
- share one framework-neutral Tried-result evaluator with
  `NexusLabs.Xunit.Assertions`
- bundle the NLT0001 analyzer in the assertions NuGet package to report direct
  `Assert.That(result.Success|Value|Error)` usage
- add real TUnit behavior/analyzer tests and a post-pack consumer smoke test
- update package docs, analyzer docs, changelog, solution wiring, and TUnit
  dependencies

## Consumer API

```csharp
var value = await Assert.That(result)
    .Succeeded()
    .Because("The operation should succeed");

var error = await Assert.That(result)
    .Failed()
    .With<ArgumentException>()
    .Because("Invalid input should be rejected");
```

## Validation

- Release build: 0 warnings, 0 errors
- Tests: 797 total; 796 passed, 0 failed, 1 pre-existing skipped
- Pack: all repository NuGet packages created successfully
- Installed-package smoke:
  - real TUnit consumer passed
  - analyzer consumer failed as expected with NLT0001 promoted to an error

## Upstream guidance

Genesis instruction update requested in
https://github.com/ncosentino/genesis/issues/138.

## Deliberate scope

- no broad analyzer attempting to identify every possible custom unwrap helper
- no multi-statement code fix in the first release
- no changes to the `NexusLabs.CodeAnalysis.Testing.TUnit` package's purpose
