### PR TITLE
chore(release): prepare v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ preserved at the bottom of this file for reference.
 
 ## [Unreleased]
 
+## [0.2.7] &mdash; 2026-07-24
+
+Release adding two new packages: TUnit-native assertions for the
+`NexusLabs.Framework` result types and additive UUIDv7 creation for GUID-backed
+strongly typed identifiers. Per lockstep versioning, every `NexusLabs.*`
+package advances to 0.2.7 together.
+
 ### NexusLabs.StronglyTypedIds (new package)
 
 Added an additive UUIDv7 creation layer for GUID-backed strongly typed
@@ -44,6 +51,9 @@ identifiers:
 - Added installed-package verification for template delivery, transitive source
   generator availability, analyzer delivery, and packaged IntelliSense XML
   documentation.
+- The source-generator dependency is pinned exactly to `1.0.0-beta08`; package
+  build assets forward its generator assemblies because analyzer assets do not
+  otherwise flow through a transitive NuGet dependency.
 
 ### NexusLabs.TUnit.Assertions (new package)
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
       of the entire monorepo; the release workflow packs + pushes every package
       at the same version.
     -->
-    <Version>0.2.6</Version>
+    <Version>0.2.7</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">

--- a/src/NexusLabs.StronglyTypedIds.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/NexusLabs.StronglyTypedIds.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,2 +1,11 @@
 ﻿; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 0.2.7
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+NLS0001 | Usage    | Error    | UUIDv7-enabled identifiers must use their generated Create() method instead of the built-in New() method, which creates UUIDv4 values.
+NLS0002 | Usage    | Error    | Do not construct a UUIDv7-enabled identifier directly from Guid.NewGuid(); use the generated Create() method or pass an externally sourced GUID only when intentionally rehydrating an existing identifier.

--- a/src/NexusLabs.StronglyTypedIds.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/NexusLabs.StronglyTypedIds.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,9 +1,2 @@
-﻿; Unshipped analyzer release
+; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-NLS0001 | Usage    | Error    | UUIDv7-enabled identifiers must use their generated Create() method instead of the built-in New() method, which creates UUIDv4 values.
-NLS0002 | Usage    | Error    | Do not construct a UUIDv7-enabled identifier directly from Guid.NewGuid(); use the generated Create() method or pass an externally sourced GUID only when intentionally rehydrating an existing identifier.

--- a/src/NexusLabs.TUnit.Assertions.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/NexusLabs.TUnit.Assertions.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,2 +1,10 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 0.2.7
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+NLT0001 | Usage    | Warning  | Assert TriedEx and TriedNullEx results directly with NexusLabs.TUnit.Assertions Succeeded() or Failed() instead of passing their Success, Value, or Error properties to TUnit Assert.That.

--- a/src/NexusLabs.TUnit.Assertions.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/NexusLabs.TUnit.Assertions.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,8 +1,2 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-NLT0001 | Usage    | Warning  | Assert TriedEx and TriedNullEx results directly with NexusLabs.TUnit.Assertions Succeeded() or Failed() instead of passing their Success, Value, or Error properties to TUnit Assert.That.


### PR DESCRIPTION
## Release v0.2.7

Lockstep release advancing every `NexusLabs.*` package to **0.2.7**.

### Included since v0.2.6

- `NexusLabs.TUnit.Assertions`: native `TriedEx<T>` / `TriedNullEx<T>` assertions and bundled NLT0001 analyzer (#26)
- `NexusLabs.StronglyTypedIds`: additive UUIDv7 creation, TimeProvider-aware generation, DI support, and bundled NLS0001/NLS0002 analyzers/code fixes (#28)
- `NexusLabs.Xunit.Assertions`: shared result-evaluation implementation with unchanged public behavior (#26)
- installed-package verification for both new packages

### Changes in this PR

- `Directory.Build.props`: lockstep version `0.2.6` → `0.2.7`
- `CHANGELOG.md`: finalized the dated `0.2.7` release section

### Validation

- release build: 0 warnings, 0 errors
- tests: 818 passed, 0 failed, 1 skipped
- packed 8 `.nupkg` and 8 `.snupkg` artifacts at version 0.2.7
- TUnit and UUIDv7 installed-package smoke suites passed
- verified `0.2.7` is not already published for any package

### After merge

Tag merged `master` as `v0.2.7` and push the tag. The Release workflow will rebuild, test, pack, and publish all eight packages to NuGet.org using OIDC trusted publishing.