### PR TITLE
fix(data-sql-mysql): restore Dapper async compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ preserved at the bottom of this file for reference.
 
 ## [Unreleased]
 
+### NexusLabs.Data.Sql.MySql
+
+Fixed:
+
+- Restored standard ADO.NET runtime compatibility for the internal MySQL
+  adapters. Connections now preserve `DbConnection` identity and commands
+  preserve `DbCommand` identity while continuing to implement the
+  `IAsyncDbConnection` / `IAsyncDbCommand` contracts. Dapper 2.1.66 async
+  execution can therefore use factory-created connections without rejecting
+  the adapter types.
+- Provider-native asynchronous execution, cancellation, reader creation,
+  transaction/parameter behavior, and disposal remain directly delegated to
+  `MySqlConnection` and `MySqlCommand`; the fix does not introduce
+  sync-over-async fallback behavior.
+
 ## [0.2.7] &mdash; 2026-07-24
 
 Release adding two new packages: TUnit-native assertions for the

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,6 +37,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Testing">
+    <PackageVersion Include="Dapper" Version="2.1.66" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/src/NexusLabs.Data.Sql.MySql/AsyncMySqlCommand.cs
+++ b/src/NexusLabs.Data.Sql.MySql/AsyncMySqlCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,122 +13,197 @@ using NexusLabs.Framework.Data;
 namespace NexusLabs.Data.Sql.MySql;
 
 /// <summary>
-/// Internal adapter that wraps a <see cref="MySqlCommand"/> and exposes it as an
-/// <see cref="IAsyncDbCommand"/>. Every async overload delegates to the underlying command's
-/// own async path - never falls through to a sync-over-async base.
+/// Internal adapter that wraps a <see cref="MySqlCommand"/> and exposes it as a
+/// <see cref="DbCommand"/> and <see cref="IAsyncDbCommand"/>. Every async override delegates to
+/// the provider's native asynchronous path rather than using the base sync-over-async fallback.
 /// </summary>
-internal sealed class AsyncMySqlCommand : IAsyncDbCommand
+internal sealed class AsyncMySqlCommand :
+    DbCommand,
+    IAsyncDbCommand
 {
     [TransfersOwnership]
     private readonly MySqlCommand _command;
+    private AsyncMySqlConnection? _connection;
+    private int _disposed;
 
-    public AsyncMySqlCommand(MySqlCommand command)
+    public AsyncMySqlCommand(
+        MySqlCommand command,
+        AsyncMySqlConnection? connection = null)
     {
         ArgumentNullException.ThrowIfNull(command);
         _command = command;
+        _connection = connection;
     }
 
     [AllowNull]
-    public string CommandText
+    public override string CommandText
     {
         get => _command.CommandText;
         set => _command.CommandText = value!;
     }
 
-    public int CommandTimeout
+    public override int CommandTimeout
     {
         get => _command.CommandTimeout;
         set => _command.CommandTimeout = value;
     }
 
-    public CommandType CommandType
+    public override CommandType CommandType
     {
         get => _command.CommandType;
         set => _command.CommandType = value;
     }
 
-    public IDbConnection? Connection
+    public override bool DesignTimeVisible
     {
-        get => _command.Connection;
-        set => _command.Connection = (MySqlConnection?)value;
+        get => _command.DesignTimeVisible;
+        set => _command.DesignTimeVisible = value;
     }
 
-    public IDataParameterCollection Parameters => _command.Parameters;
-
-    public IDbTransaction? Transaction
-    {
-        get => _command.Transaction;
-        set => _command.Transaction = (MySqlTransaction?)value;
-    }
-
-    public UpdateRowSource UpdatedRowSource
+    public override UpdateRowSource UpdatedRowSource
     {
         get => _command.UpdatedRowSource;
         set => _command.UpdatedRowSource = value;
     }
 
-    public void Cancel() => _command.Cancel();
+    protected override DbConnection? DbConnection
+    {
+        get => _connection is not null
+            ? _connection
+            : _command.Connection;
+        set
+        {
+            switch (value)
+            {
+                case null:
+                    _connection = null;
+                    _command.Connection = null;
+                    break;
+                case AsyncMySqlConnection connection:
+                    _connection = connection;
+                    _command.Connection = connection.InnerConnection;
+                    break;
+                case MySqlConnection connection:
+                    _connection = null;
+                    _command.Connection = connection;
+                    break;
+                default:
+                    throw new ArgumentException(
+                        $"Connection must be a {nameof(MySqlConnection)} or " +
+                        $"{nameof(AsyncMySqlConnection)}.",
+                        nameof(value));
+            }
+        }
+    }
 
-    public IDbDataParameter CreateParameter() => _command.CreateParameter();
+    protected override DbParameterCollection DbParameterCollection =>
+        _command.Parameters;
 
-    public void Dispose() => _command.Dispose();
-    public ValueTask DisposeAsync() => _command.DisposeAsync();
+    protected override DbTransaction? DbTransaction
+    {
+        get => _command.Transaction;
+        set => _command.Transaction = value switch
+        {
+            null => null,
+            MySqlTransaction transaction => transaction,
+            _ => throw new ArgumentException(
+                $"Transaction must be a {nameof(MySqlTransaction)}.",
+                nameof(value)),
+        };
+    }
 
-    public int ExecuteNonQuery() => _command.ExecuteNonQuery();
-    public Task<int> ExecuteNonQueryAsync() => _command.ExecuteNonQueryAsync();
-    public Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken) =>
+    public override void Cancel() => _command.Cancel();
+
+    public override int ExecuteNonQuery() => _command.ExecuteNonQuery();
+
+    public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken) =>
         _command.ExecuteNonQueryAsync(cancellationToken);
 
-    public IDataReader ExecuteReader() => _command.ExecuteReader();
-    public IDataReader ExecuteReader(CommandBehavior behavior) => _command.ExecuteReader(behavior);
+    public override object? ExecuteScalar() => _command.ExecuteScalar();
 
-    public async Task<IAsyncDbDataReader> ExecuteReaderAsync()
+    public override Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken) =>
+        _command.ExecuteScalarAsync(cancellationToken);
+
+    public override void Prepare() => _command.Prepare();
+
+    public override Task PrepareAsync(CancellationToken cancellationToken) =>
+        _command.PrepareAsync(cancellationToken);
+
+    protected override DbParameter CreateDbParameter() =>
+        _command.CreateParameter();
+
+    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) =>
+        _command.ExecuteReader(behavior);
+
+    protected override async Task<DbDataReader> ExecuteDbDataReaderAsync(
+        CommandBehavior behavior,
+        CancellationToken cancellationToken) =>
+        await _command
+            .ExecuteReaderAsync(behavior, cancellationToken)
+            .ConfigureAwait(false);
+
+    protected override void Dispose(bool disposing)
     {
-        var reader = await _command
+        try
+        {
+            if (disposing && Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                _command.Dispose();
+            }
+        }
+        finally
+        {
+            base.Dispose(disposing);
+        }
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await _command.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    async Task<IAsyncDbDataReader> IAsyncDbCommand.ExecuteReaderAsync() =>
+        new AsyncMySqlDataReader((MySqlDataReader)await _command
             .ExecuteReaderAsync()
-            .ConfigureAwait(false);
-        return new AsyncMySqlDataReader((MySqlDataReader)reader);
-    }
+            .ConfigureAwait(false));
 
-    public async Task<IAsyncDbDataReader> ExecuteReaderAsync(CommandBehavior commandBehavior)
-    {
-        var reader = await _command
+    async Task<IAsyncDbDataReader> IAsyncDbCommand.ExecuteReaderAsync(
+        CommandBehavior commandBehavior) =>
+        new AsyncMySqlDataReader((MySqlDataReader)await _command
             .ExecuteReaderAsync(commandBehavior)
-            .ConfigureAwait(false);
-        return new AsyncMySqlDataReader((MySqlDataReader)reader);
-    }
+            .ConfigureAwait(false));
 
-    public async Task<IAsyncDbDataReader> ExecuteReaderAsync(
+    async Task<IAsyncDbDataReader> IAsyncDbCommand.ExecuteReaderAsync(
         CommandBehavior commandBehavior,
-        CancellationToken cancellationToken)
-    {
-        var reader = await _command
+        CancellationToken cancellationToken) =>
+        new AsyncMySqlDataReader((MySqlDataReader)await _command
             .ExecuteReaderAsync(commandBehavior, cancellationToken)
-            .ConfigureAwait(false);
-        return new AsyncMySqlDataReader((MySqlDataReader)reader);
-    }
+            .ConfigureAwait(false));
 
-    public async Task<IAsyncDbDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
-    {
-        var reader = await _command
+    async Task<IAsyncDbDataReader> IAsyncDbCommand.ExecuteReaderAsync(
+        CancellationToken cancellationToken) =>
+        new AsyncMySqlDataReader((MySqlDataReader)await _command
             .ExecuteReaderAsync(cancellationToken)
-            .ConfigureAwait(false);
-        return new AsyncMySqlDataReader((MySqlDataReader)reader);
-    }
+            .ConfigureAwait(false));
 
-    public object? ExecuteScalar() => _command.ExecuteScalar();
-    public async Task<object> ExecuteScalarAsync()
-    {
-        var result = await _command.ExecuteScalarAsync().ConfigureAwait(false);
-        return result!;
-    }
-    public async Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
-    {
-        var result = await _command
+    async Task<object> IAsyncDbCommand.ExecuteScalarAsync() =>
+        (await _command.ExecuteScalarAsync().ConfigureAwait(false))!;
+
+    async Task<object> IAsyncDbCommand.ExecuteScalarAsync(
+        CancellationToken cancellationToken) =>
+        (await _command
             .ExecuteScalarAsync(cancellationToken)
-            .ConfigureAwait(false);
-        return result!;
-    }
-
-    public void Prepare() => _command.Prepare();
+            .ConfigureAwait(false))!;
 }

--- a/src/NexusLabs.Data.Sql.MySql/AsyncMySqlConnection.cs
+++ b/src/NexusLabs.Data.Sql.MySql/AsyncMySqlConnection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,50 +14,167 @@ namespace NexusLabs.Data.Sql.MySql;
 
 /// <summary>
 /// Internal adapter that wraps a <see cref="MySqlConnection"/> and exposes it as an
-/// <see cref="IAsyncDbConnection"/>. Commands created via this connection are wrapped with
-/// <see cref="AsyncMySqlCommand"/> so their async paths are also properly delegated.
+/// <see cref="DbConnection"/> and <see cref="IAsyncDbConnection"/>. Commands created via this
+/// connection preserve the standard <see cref="DbCommand"/> runtime contract while delegating
+/// provider-native asynchronous operations.
 /// </summary>
-internal sealed class AsyncMySqlConnection : IAsyncDbConnection
+internal sealed class AsyncMySqlConnection :
+    DbConnection,
+    IAsyncDbConnection
 {
     [TransfersOwnership]
     private readonly MySqlConnection _connection;
+    private int _disposed;
 
     public AsyncMySqlConnection(MySqlConnection connection)
     {
         ArgumentNullException.ThrowIfNull(connection);
         _connection = connection;
+        _connection.StateChange += HandleStateChange;
     }
 
+    internal MySqlConnection InnerConnection => _connection;
+
     [AllowNull]
-    public string ConnectionString
+    public override string ConnectionString
     {
         get => _connection.ConnectionString;
         set => _connection.ConnectionString = value!;
     }
 
-    public int ConnectionTimeout => _connection.ConnectionTimeout;
+    public override int ConnectionTimeout => _connection.ConnectionTimeout;
 
-    public string Database => _connection.Database;
+    public override string Database => _connection.Database;
 
-    public ConnectionState State => _connection.State;
+    public override string DataSource => _connection.DataSource;
 
-    public IDbTransaction BeginTransaction() => _connection.BeginTransaction();
+    public override string ServerVersion => _connection.ServerVersion;
 
-    public IDbTransaction BeginTransaction(IsolationLevel il) => _connection.BeginTransaction(il);
+    public override ConnectionState State => _connection.State;
 
-    public void ChangeDatabase(string databaseName) => _connection.ChangeDatabase(databaseName);
+    public override bool CanCreateBatch => _connection.CanCreateBatch;
 
-    public void Close() => _connection.Close();
+    public override void ChangeDatabase(string databaseName) =>
+        _connection.ChangeDatabase(databaseName);
 
-    public IAsyncDbCommand CreateAsyncCommand() => new AsyncMySqlCommand(_connection.CreateCommand());
+    public override Task ChangeDatabaseAsync(
+        string databaseName,
+        CancellationToken cancellationToken) =>
+        _connection.ChangeDatabaseAsync(databaseName, cancellationToken);
 
-    public IDbCommand CreateCommand() => CreateAsyncCommand();
+    public override void Close() => _connection.Close();
 
-    public void Dispose() => _connection.Dispose();
-    public ValueTask DisposeAsync() => _connection.DisposeAsync();
+    public override Task CloseAsync() => _connection.CloseAsync();
 
-    public void Open() => _connection.Open();
-    public Task OpenAsync() => _connection.OpenAsync();
-    public Task OpenAsync(CancellationToken cancellationToken) =>
+    public IAsyncDbCommand CreateAsyncCommand() =>
+        (IAsyncDbCommand)CreateDbCommand();
+
+    IDbTransaction IDbConnection.BeginTransaction() =>
+        _connection.BeginTransaction();
+
+    IDbTransaction IDbConnection.BeginTransaction(IsolationLevel isolationLevel) =>
+        isolationLevel == IsolationLevel.Unspecified
+            ? _connection.BeginTransaction()
+            : _connection.BeginTransaction(isolationLevel);
+
+    public override void EnlistTransaction(System.Transactions.Transaction? transaction) =>
+        _connection.EnlistTransaction(transaction);
+
+    public override DataTable GetSchema() => _connection.GetSchema();
+
+    public override DataTable GetSchema(string collectionName) =>
+        _connection.GetSchema(collectionName);
+
+    public override DataTable GetSchema(
+        string collectionName,
+        string?[] restrictionValues) =>
+        _connection.GetSchema(collectionName, restrictionValues);
+
+    public override Task<DataTable> GetSchemaAsync(CancellationToken cancellationToken) =>
+        _connection.GetSchemaAsync(cancellationToken);
+
+    public override Task<DataTable> GetSchemaAsync(
+        string collectionName,
+        CancellationToken cancellationToken) =>
+        _connection.GetSchemaAsync(collectionName, cancellationToken);
+
+    public override Task<DataTable> GetSchemaAsync(
+        string collectionName,
+        string?[] restrictionValues,
+        CancellationToken cancellationToken) =>
+        _connection.GetSchemaAsync(collectionName, restrictionValues, cancellationToken);
+
+    public override void Open() => _connection.Open();
+
+    public override Task OpenAsync(CancellationToken cancellationToken) =>
         _connection.OpenAsync(cancellationToken);
+
+    protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) =>
+        isolationLevel == IsolationLevel.Unspecified
+            ? _connection.BeginTransaction()
+            : _connection.BeginTransaction(isolationLevel);
+
+    protected override async ValueTask<DbTransaction> BeginDbTransactionAsync(
+        IsolationLevel isolationLevel,
+        CancellationToken cancellationToken)
+    {
+        if (isolationLevel == IsolationLevel.Unspecified)
+        {
+            return await _connection
+                .BeginTransactionAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return await _connection
+            .BeginTransactionAsync(isolationLevel, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    protected override DbBatch CreateDbBatch() => _connection.CreateBatch();
+
+    protected override DbCommand CreateDbCommand() =>
+        new AsyncMySqlCommand(_connection.CreateCommand(), this);
+
+    protected override DbProviderFactory DbProviderFactory =>
+        MySqlClientFactory.Instance;
+
+    protected override void Dispose(bool disposing)
+    {
+        try
+        {
+            if (disposing && Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                _connection.StateChange -= HandleStateChange;
+                _connection.Dispose();
+            }
+        }
+        finally
+        {
+            base.Dispose(disposing);
+        }
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        _connection.StateChange -= HandleStateChange;
+        try
+        {
+            await _connection.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private void HandleStateChange(object sender, StateChangeEventArgs e)
+    {
+        _ = sender;
+        OnStateChange(e);
+    }
 }

--- a/tests/NexusLabs.Data.Sql.MySql.Tests/AsyncMySqlConnectionTests.cs
+++ b/tests/NexusLabs.Data.Sql.MySql.Tests/AsyncMySqlConnectionTests.cs
@@ -1,4 +1,6 @@
 using System.Data;
+using System.Data.Common;
+using System.Reflection;
 
 using MySql.Data.MySqlClient;
 
@@ -38,6 +40,7 @@ public sealed class AsyncMySqlConnectionTests
         using var cmd = sut.CreateAsyncCommand();
 
         Assert.IsType<AsyncMySqlCommand>(cmd);
+        Assert.IsAssignableFrom<DbCommand>(cmd);
     }
 
     [Fact]
@@ -50,5 +53,63 @@ public sealed class AsyncMySqlConnectionTests
         cmd.CommandText = "SELECT 1";
 
         Assert.Equal("SELECT 1", cmd.CommandText);
+    }
+
+    [Fact]
+    public void Adapter_OverridesProviderNativeAsyncExecutionPaths()
+    {
+        AssertDeclaredOverride(
+            nameof(DbCommand.ExecuteNonQueryAsync),
+            BindingFlags.Instance | BindingFlags.Public,
+            typeof(CancellationToken));
+        AssertDeclaredOverride(
+            nameof(DbCommand.ExecuteScalarAsync),
+            BindingFlags.Instance | BindingFlags.Public,
+            typeof(CancellationToken));
+        AssertDeclaredOverride(
+            "ExecuteDbDataReaderAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            typeof(CommandBehavior),
+            typeof(CancellationToken));
+        AssertDeclaredOverride(
+            nameof(DbCommand.PrepareAsync),
+            BindingFlags.Instance | BindingFlags.Public,
+            typeof(CancellationToken));
+        AssertDeclaredOverride(
+            nameof(DbCommand.DisposeAsync),
+            BindingFlags.Instance | BindingFlags.Public);
+    }
+
+    [Fact]
+    public void Adapter_PreservesExplicitIdbConnectionTransactionDispatch()
+    {
+        var interfaceMap = typeof(AsyncMySqlConnection)
+            .GetInterfaceMap(typeof(IDbConnection));
+        var beginTransactionTargets = interfaceMap.InterfaceMethods
+            .Select((method, index) => (method, target: interfaceMap.TargetMethods[index]))
+            .Where(x => x.method.Name == nameof(IDbConnection.BeginTransaction))
+            .Select(x => x.target.DeclaringType)
+            .ToArray();
+
+        Assert.Equal(2, beginTransactionTargets.Length);
+        Assert.All(
+            beginTransactionTargets,
+            declaringType => Assert.Equal(typeof(AsyncMySqlConnection), declaringType));
+    }
+
+    private static void AssertDeclaredOverride(
+        string methodName,
+        BindingFlags bindingFlags,
+        params Type[] parameterTypes)
+    {
+        var method = typeof(AsyncMySqlCommand).GetMethod(
+            methodName,
+            bindingFlags,
+            binder: null,
+            parameterTypes,
+            modifiers: null);
+
+        Assert.NotNull(method);
+        Assert.Equal(typeof(AsyncMySqlCommand), method.DeclaringType);
     }
 }

--- a/tests/NexusLabs.Data.Sql.MySql.Tests/DapperCompatibilityTests.cs
+++ b/tests/NexusLabs.Data.Sql.MySql.Tests/DapperCompatibilityTests.cs
@@ -1,0 +1,89 @@
+using System.Data.Common;
+
+using Dapper;
+
+using NexusLabs.Framework.Data;
+
+using Xunit;
+
+namespace NexusLabs.Data.Sql.MySql.Tests;
+
+public sealed class DapperCompatibilityTests
+{
+    private readonly CancellationToken _ct = TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task FactoryConnection_PreservesStandardAdoNetRuntimeTypes()
+    {
+        var factory = CreateFactory();
+        await using var connection = await factory.CreateNewConnectionAsync(_ct);
+
+        var dbConnection = Assert.IsAssignableFrom<DbConnection>(connection);
+        await using var dbCommand = Assert.IsAssignableFrom<DbCommand>(
+            connection.CreateCommand());
+
+        Assert.Same(dbConnection, dbCommand.Connection);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPreCanceledCommand_PassesDapperTypeGates()
+    {
+        var factory = CreateFactory();
+        await using IAsyncDbConnection connection =
+            await factory.CreateNewConnectionAsync(_ct);
+        using var cancellationTokenSource =
+            CancellationTokenSource.CreateLinkedTokenSource(_ct);
+        cancellationTokenSource.Cancel();
+        var command = new CommandDefinition(
+            "SELECT 1",
+            cancellationToken: cancellationTokenSource.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => connection.ExecuteAsync(command));
+    }
+
+    [Fact]
+    public async Task QueryAsync_WithPreCanceledCommand_PassesDapperTypeGates()
+    {
+        var factory = CreateFactory();
+        await using IAsyncDbConnection connection =
+            await factory.CreateNewConnectionAsync(_ct);
+        using var cancellationTokenSource =
+            CancellationTokenSource.CreateLinkedTokenSource(_ct);
+        cancellationTokenSource.Cancel();
+        var command = new CommandDefinition(
+            "SELECT 1",
+            cancellationToken: cancellationTokenSource.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => connection.QueryAsync<int>(command));
+    }
+
+    [Fact]
+    public async Task ExecuteReaderAsync_WithPreCanceledCommand_PassesDapperTypeGates()
+    {
+        var factory = CreateFactory();
+        await using IAsyncDbConnection connection =
+            await factory.CreateNewConnectionAsync(_ct);
+        using var cancellationTokenSource =
+            CancellationTokenSource.CreateLinkedTokenSource(_ct);
+        cancellationTokenSource.Cancel();
+        var command = new CommandDefinition(
+            "SELECT 1",
+            cancellationToken: cancellationTokenSource.Token);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => connection.ExecuteReaderAsync(command));
+    }
+
+    private static MySqlConnectionFactory CreateFactory() =>
+        new(new MySqlConnectionConfiguration(
+            Server: "127.0.0.1",
+            Port: 1,
+            Database: "test",
+            Username: "test",
+            Password: "test",
+            MinimumPoolSize: 0,
+            SslMode: "Disabled",
+            MaximumPoolSize: 1));
+}

--- a/tests/NexusLabs.Data.Sql.MySql.Tests/NexusLabs.Data.Sql.MySql.Tests.csproj
+++ b/tests/NexusLabs.Data.Sql.MySql.Tests/NexusLabs.Data.Sql.MySql.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapper" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- restore standard `DbConnection` / `DbCommand` runtime identity on the internal MySQL adapters while retaining `IAsyncDbConnection` / `IAsyncDbCommand`
- preserve provider-native async execution, cancellation, reader, parameter, transaction, state-change, and disposal behavior
- preserve the provider's existing parameterless transaction isolation behavior across interface and BCL dispatch paths
- add Dapper 2.1.66 regression coverage and document the fix in the changelog

## Validation

- `dotnet build --configuration Release`: 0 warnings, 0 errors
- `dotnet test --no-build --configuration Release`: 824 passed, 0 failed, 1 pre-existing skipped
- targeted `NexusLabs.Data.Sql.MySql.Tests`: 33 passed, 0 failed, 0 skipped
- packed `NexusLabs.Data.Sql.MySql` was consumed through an isolated NuGet cache and passed Dapper's async command setup and cancellation path

## Scope boundary

- this fixes direct `MySqlConnectionFactory` connections, including Dapper auto-opening closed connections
- generic lease/open-tracking decorators remain interface-only; already-open decorated connections inherit command compatibility, but Dapper still cannot auto-open a closed decorated connection
- Framework CI does not currently execute a successful query against a live MySQL instance; the originating consumer reproduced the failure against MySQL 8.0