### PR TITLE
chore(release): prepare v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ preserved at the bottom of this file for reference.
 
 ## [Unreleased]
 
+## [0.2.8] &mdash; 2026-07-27
+
+Patch release restoring Dapper asynchronous compatibility for the MySQL data
+package. Per lockstep versioning, every `NexusLabs.*` package advances to
+0.2.8 together.
+
 ### NexusLabs.Data.Sql.MySql
 
 Fixed:
@@ -33,6 +39,20 @@ Fixed:
   transaction/parameter behavior, and disposal remain directly delegated to
   `MySqlConnection` and `MySqlCommand`; the fix does not introduce
   sync-over-async fallback behavior.
+- Preserved the provider's existing parameterless transaction-isolation
+  behavior across both `IDbConnection` and `DbConnection` dispatch paths.
+
+### Build and testing
+
+Changed:
+
+- Added Dapper 2.1.66 as a test-only dependency and regression coverage for
+  `ExecuteAsync`, `QueryAsync`, and async reader setup. Dapper is not a runtime
+  dependency of any published package.
+- Updated `Microsoft.Extensions.Logging.Abstractions` to 10.0.10,
+  `Microsoft.SourceLink.GitHub` to 10.0.301,
+  `Microsoft.Extensions.TimeProvider.Testing` to 10.8.0,
+  `Microsoft.NET.Test.Sdk` to 18.8.1, and TUnit / TUnit.Assertions to 1.61.38.
 
 ## [0.2.7] &mdash; 2026-07-24
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
       of the entire monorepo; the release workflow packs + pushes every package
       at the same version.
     -->
-    <Version>0.2.7</Version>
+    <Version>0.2.8</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">


### PR DESCRIPTION
## Summary

- bump the lockstep package version from `0.2.7` to `0.2.8`
- finalize release notes for the MySQL/Dapper async compatibility fix
- document the six dependency updates included since `v0.2.7`

## Validation

- `dotnet build --configuration Release`: 0 warnings, 0 errors
- `dotnet test --no-build --configuration Release`: 824 passed, 0 failed, 1 pre-existing skipped
- produced 8 `.nupkg` and 8 `.snupkg` artifacts at version `0.2.8`
- installed-package verification passed for `NexusLabs.TUnit.Assertions`
- installed-package verification passed for `NexusLabs.StronglyTypedIds`
- isolated-cache consumer smoke passed for `NexusLabs.Data.Sql.MySql` with Dapper 2.1.66
- inspected the MySQL package dependency graph: Dapper remains test-only and is not a published runtime dependency

## Release scope

- restores Dapper asynchronous compatibility for direct `MySqlConnectionFactory` connections
- preserves provider-native async execution, cancellation, disposal, and parameterless transaction defaults
- advances all eight packages under the repository's lockstep versioning policy