### PR TITLE
ci: migrate to Genesis PR delivery model

### DIFF
--- a/.genesis/delivery/private-auto-merge.yml
+++ b/.genesis/delivery/private-auto-merge.yml
@@ -1,0 +1,246 @@
+name: Private PR auto-merge
+
+on:
+  workflow_run:
+    workflows:
+      # __GENESIS_WORKFLOW_NAMES__
+    types: [completed]
+
+permissions:
+  checks: read
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: private-auto-merge-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  merge:
+    name: Merge tested pull request
+    if: >-
+      vars.GENESIS_DELIVERY_MODEL == 'workflow-run' &&
+      (
+        github.event.workflow_run.event == 'pull_request' ||
+        (
+          github.event.workflow_run.path == '.github/workflows/pr-review-policy.yml' &&
+          (
+            github.event.workflow_run.event == 'pull_request_target' ||
+            github.event.workflow_run.event == 'pull_request_review'
+          )
+        )
+      ) &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_PROMPT_DISABLED: '1'
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      GIT_TERMINAL_PROMPT: '0'
+      REQUIRED_CHECK_APP_ID: '15368'
+      TRIGGER_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+      TRIGGER_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      TRIGGER_WORKFLOW_PATH: ${{ github.event.workflow_run.path }}
+    steps:
+      - name: Merge the exact tested pull request
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tested_sha="$TRIGGER_HEAD_SHA"
+          trigger_pr_number=''
+          if [ "$TRIGGER_WORKFLOW_PATH" = '.github/workflows/pr-review-policy.yml' ]; then
+            if [[ "$TRIGGER_DISPLAY_TITLE" =~ ^Review\ policy\ for\ \#([0-9]+)\ at\ ([0-9a-f]{40})$ ]]; then
+              trigger_pr_number="${BASH_REMATCH[1]}"
+              tested_sha="${BASH_REMATCH[2]}"
+            else
+              echo "::error::Review policy run title does not identify an exact pull request SHA."
+              exit 1
+            fi
+          fi
+
+          repository="$(gh api "repos/$GH_REPO")"
+          default_branch="$(jq -r '.default_branch' <<<"$repository")"
+          repository_id="$(jq -r '.id' <<<"$repository")"
+          contract="$(
+            gh api \
+              -H 'Accept: application/vnd.github.raw+json' \
+              "repos/$GH_REPO/contents/.github/genesis-delivery.json?ref=$default_branch"
+          )"
+
+          pull_requests="$(
+            gh api "repos/$GH_REPO/commits/$tested_sha/pulls" |
+              jq --arg sha "$tested_sha" --arg repo "$GH_REPO" --arg base "$default_branch" '
+                [
+                  .[]
+                  | select(
+                      .state == "open"
+                      and .base.ref == $base
+                      and .head.sha == $sha
+                      and .head.repo.full_name == $repo
+                      and .draft == false
+                    )
+                ]
+              '
+          )"
+          pull_request_count="$(jq 'length' <<<"$pull_requests")"
+
+          if [ "$pull_request_count" -eq 0 ]; then
+            echo "No ready same-repository pull request targets $default_branch at $tested_sha."
+            exit 0
+          fi
+          if [ "$pull_request_count" -ne 1 ]; then
+            echo "::error::$pull_request_count pull requests match tested commit $tested_sha."
+            exit 1
+          fi
+
+          pull_request_number="$(jq -r '.[0].number' <<<"$pull_requests")"
+          if [ -n "$trigger_pr_number" ] && [ "$pull_request_number" != "$trigger_pr_number" ]; then
+            echo "::error::Review policy run identified pull request $trigger_pr_number, but commit lookup found $pull_request_number."
+            exit 1
+          fi
+          pull_request="$(gh api "repos/$GH_REPO/pulls/$pull_request_number")"
+          current_sha="$(jq -r '.head.sha' <<<"$pull_request")"
+          current_base="$(jq -r '.base.ref' <<<"$pull_request")"
+          current_repo="$(jq -r '.head.repo.full_name' <<<"$pull_request")"
+          head_ref="$(jq -r '.head.ref // empty' <<<"$pull_request")"
+          head_repo_id="$(jq -r '.head.repo.id // empty' <<<"$pull_request")"
+          base_repo_id="$(jq -r '.base.repo.id // empty' <<<"$pull_request")"
+          current_state="$(jq -r '.state' <<<"$pull_request")"
+          current_draft="$(jq -r '.draft' <<<"$pull_request")"
+          current_title="$(jq -r '.title' <<<"$pull_request")"
+
+          if [ "$current_state" != "open" ] ||
+             [ "$current_draft" != "false" ] ||
+             [ "$current_base" != "$default_branch" ] ||
+             [ "$current_repo" != "$GH_REPO" ] ||
+             [ "$current_sha" != "$tested_sha" ]; then
+            echo "Pull request $pull_request_number changed after validation; leaving it open."
+            exit 0
+          fi
+          if [ -z "$head_ref" ] ||
+             [ "$head_repo_id" != "$repository_id" ] ||
+             [ "$base_repo_id" != "$repository_id" ] ||
+             [ "$head_ref" = "$default_branch" ]; then
+            echo "::error::Pull request $pull_request_number does not have a deletable same-repository head branch."
+            exit 1
+          fi
+          full_ref="refs/heads/$head_ref"
+          git check-ref-format --branch "$head_ref" >/dev/null
+          git check-ref-format "$full_ref" >/dev/null
+
+          title_pattern="$(jq -r '.pullRequestTitle.pattern' <<<"$contract")"
+          title_max_length="$(jq -r '.pullRequestTitle.maxLength' <<<"$contract")"
+          if [[ "$current_title" == *$'\n'* || "$current_title" == *$'\r'* ]] ||
+             (( ${#current_title} > title_max_length )) ||
+             [[ ! "$current_title" =~ $title_pattern ]]; then
+            echo "::error::Pull request $pull_request_number has an invalid conventional title."
+            exit 1
+          fi
+
+          check_runs="$(
+            gh api \
+              --paginate \
+              --slurp \
+              "repos/$GH_REPO/commits/$tested_sha/check-runs?filter=latest&per_page=100" |
+              jq '{check_runs: [.[].check_runs[]]}'
+          )"
+          while IFS= read -r required_check; do
+            conclusion="$(
+              jq -r \
+                --arg name "$required_check" \
+                --argjson app_id "$REQUIRED_CHECK_APP_ID" '
+                [
+                  .check_runs[]
+                  | select(.name == $name and .app.id == $app_id)
+                ] | first | .conclusion // ""
+              ' <<<"$check_runs"
+            )"
+            if [ "$conclusion" != "success" ]; then
+              echo "Required check '$required_check' is '$conclusion'; leaving pull request open."
+              exit 0
+            fi
+          done < <(jq -r '.requiredChecks[]' <<<"$contract")
+
+          current_base_sha="$(gh api "repos/$GH_REPO/commits/$default_branch" --jq '.sha')"
+          comparison_status="$(
+            gh api "repos/$GH_REPO/compare/$current_base_sha...$tested_sha" --jq '.status'
+          )"
+          if [ "$comparison_status" != 'ahead' ] && [ "$comparison_status" != 'identical' ]; then
+            echo "Pull request $pull_request_number does not contain current $default_branch commit $current_base_sha; update the branch and rerun CI."
+            exit 0
+          fi
+
+          merge_response="$(
+            gh api \
+              --method PUT \
+              "repos/$GH_REPO/pulls/$pull_request_number/merge" \
+              -f merge_method=squash \
+              -f sha="$tested_sha"
+          )"
+          if [ "$(jq -r '.merged' <<<"$merge_response")" != "true" ]; then
+            message="$(jq -r '.message // "GitHub declined the merge."' <<<"$merge_response")"
+            echo "::error::Pull request $pull_request_number was not merged: $message"
+            exit 1
+          fi
+
+          merge_sha="$(jq -r '.sha' <<<"$merge_response")"
+          echo "Merged pull request $pull_request_number at $merge_sha."
+
+          cleanup_default="$(gh api "repos/$GH_REPO" --jq '.default_branch')"
+          if [ "$head_ref" = "$cleanup_default" ]; then
+            echo "::error::Refusing to delete the current default branch '$head_ref'."
+            exit 1
+          fi
+
+          control_repo="$(mktemp -d "${RUNNER_TEMP:?}/genesis-merge-control.XXXXXX")"
+          trap 'rm -rf "$control_repo"' EXIT
+          git init --quiet "$control_repo"
+          gh auth setup-git --hostname github.com --force
+          remote_url="https://github.com/${GH_REPO}.git"
+
+          set +e
+          push_output="$(
+            git -C "$control_repo" push --porcelain \
+              "--force-with-lease=${full_ref}:${tested_sha}" \
+              "$remote_url" \
+              ":${full_ref}" 2>&1
+          )"
+          push_status=$?
+          set -e
+          printf '%s\n' "$push_output"
+
+          if (( push_status == 0 )); then
+            echo "Deleted merged head branch '$head_ref' at $tested_sha."
+            exit 0
+          fi
+
+          set +e
+          remote_record="$(
+            git -C "$control_repo" ls-remote \
+              --quiet --exit-code --refs \
+              "$remote_url" "$full_ref" 2>&1
+          )"
+          lookup_status=$?
+          set -e
+
+          case "$lookup_status" in
+            2)
+              echo "Head branch '$head_ref' is already absent; cleanup succeeded."
+              ;;
+            0)
+              read -r remote_sha _ <<<"$remote_record"
+              if [ "$remote_sha" != "$tested_sha" ]; then
+                echo "::error::Head branch advanced to $remote_sha; refusing deletion."
+              else
+                echo "::error::Head branch remains at $tested_sha, but deletion was rejected."
+              fi
+              exit 1
+              ;;
+            *)
+              printf '%s\n' "$remote_record" >&2
+              echo "::error::Unable to determine branch state after deletion failure."
+              exit 1
+              ;;
+          esac

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Allows initial default-branch creation only against an empty remote.
+# Every later default-branch update or deletion remains blocked.
+
+default_branch="$(git config --get genesis.defaultBranch)"
+if [ -z "$default_branch" ]; then
+    default_branch="main"
+fi
+protected_ref="refs/heads/$default_branch"
+zero_oid="0000000000000000000000000000000000000000"
+remote_url="$2"
+remote_heads_checked=false
+remote_heads=""
+
+while read local_ref local_oid remote_ref remote_oid; do
+    if [ "$remote_ref" != "$protected_ref" ]; then
+        continue
+    fi
+
+    if [ "$local_oid" != "$zero_oid" ] && [ "$remote_oid" = "$zero_oid" ]; then
+        if [ "$remote_heads_checked" = "false" ]; then
+            if ! remote_heads="$(git ls-remote --heads "$remote_url" 2>/dev/null)"; then
+                echo "Unable to inspect the remote before creating '$default_branch'." >&2
+                exit 1
+            fi
+            remote_heads_checked=true
+        fi
+        if [ -z "$remote_heads" ]; then
+            continue
+        fi
+    fi
+
+    echo ""
+    echo "Direct pushes to '$default_branch' are forbidden."
+    echo "Push a feature branch and deliver the change through a pull request."
+    echo ""
+    exit 1
+done
+
+exit 0

--- a/.github/genesis-delivery.json
+++ b/.github/genesis-delivery.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "./genesis-delivery.schema.json",
+  "schemaVersion": 1,
+  "template": "nuget-library",
+  "defaultBranch": "master",
+  "ciWorkflow": "CI",
+  "requiredChecks": [
+    "CI",
+    "PR title",
+    "Review policy"
+  ],
+  "draftValidation": {
+    "hostedDefault": "ready-only",
+    "pitcrewDefault": "full",
+    "subsetJobs": []
+  },
+  "runnerProfiles": [],
+  "componentWorkflows": [
+    {
+      "source": "repository",
+      "path": ".github/workflows/release.yml",
+      "roles": [
+        "release-deploy"
+      ],
+      "draftBehavior": "not-applicable",
+      "requiredChecks": []
+    }
+  ],
+  "pullRequestTitle": {
+    "pattern": "^(feat|fix|docs|refactor|test|style|build|ci|chore|perf|revert)(\\([a-z0-9][a-z0-9._/-]*\\))?!?: .+$",
+    "maxLength": 72
+  },
+  "squashMerge": {
+    "method": "squash",
+    "title": "PR_TITLE",
+    "message": "PR_BODY"
+  }
+}

--- a/.github/genesis-delivery.schema.json
+++ b/.github/genesis-delivery.schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://ncosentino.github.io/genesis/schemas/genesis-delivery.schema.json",
+  "title": "Genesis generated-project delivery contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "template",
+    "defaultBranch",
+    "ciWorkflow",
+    "requiredChecks",
+    "draftValidation",
+    "runnerProfiles",
+    "componentWorkflows",
+    "pullRequestTitle",
+    "squashMerge"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "./genesis-delivery.schema.json"
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "template": {
+      "type": "string",
+      "minLength": 1
+    },
+    "defaultBranch": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ciWorkflow": {
+      "type": "string",
+      "minLength": 1
+    },
+    "requiredChecks": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "draftValidation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hostedDefault", "pitcrewDefault", "subsetJobs"],
+      "properties": {
+        "hostedDefault": {
+          "enum": ["full", "subset", "ready-only"]
+        },
+        "pitcrewDefault": {
+          "enum": ["full", "subset", "ready-only"]
+        },
+        "subsetJobs": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "runnerProfiles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "source", "labels", "jobs"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$"
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1
+          },
+          "labels": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "jobs": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "componentWorkflows": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source", "path", "roles", "draftBehavior", "requiredChecks"],
+        "properties": {
+          "source": {
+            "type": "string",
+            "minLength": 1
+          },
+          "path": {
+            "type": "string",
+            "pattern": "^\\.github/workflows/.+\\.ya?ml$"
+          },
+          "roles": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "enum": ["merge-gate", "draft-optional", "post-merge", "release-deploy"]
+            }
+          },
+          "draftBehavior": {
+            "enum": ["full", "subset", "ready-only", "not-applicable"]
+          },
+          "requiredChecks": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "pullRequestTitle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pattern", "maxLength"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "minLength": 1
+        },
+        "maxLength": {
+          "const": 72
+        }
+      }
+    },
+    "squashMerge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["method", "title", "message"],
+      "properties": {
+        "method": {
+          "const": "squash"
+        },
+        "title": {
+          "const": "PR_TITLE"
+        },
+        "message": {
+          "const": "PR_BODY"
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,17 @@ name: CI
 on:
   pull_request:
     branches: [master]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [master]
   workflow_dispatch:
+    inputs:
+      validation_scope:
+        description: 'Validation scope for this branch dispatch'
+        required: false
+        default: 'full'
+        type: choice
+        options: [full, subset]
 
 permissions:
   contents: read
@@ -16,7 +23,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validation-plan:
+    name: Validation plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      scope: ${{ steps.scope.outputs.scope }}
+    steps:
+      - name: Resolve validation scope
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IS_DRAFT: ${{ github.event.pull_request.draft || false }}
+          REQUESTED_SCOPE: ${{ inputs.validation_scope || '' }}
+          DRAFT_MODE: ${{ vars.CI_DRAFT_MODE || 'ready-only' }}
+        run: |
+          scope=full
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then scope="$REQUESTED_SCOPE"; fi
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$IS_DRAFT" = "true" ]; then scope="$DRAFT_MODE"; fi
+          case "$scope" in full|subset|ready-only) ;; *) exit 1 ;; esac
+          if [ "$scope" = "subset" ]; then scope=full; fi
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+
   build-and-test:
+    needs: validation-plan
+    if: needs.validation-plan.outputs.scope == 'full'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -63,3 +94,20 @@ jobs:
           path: |
             ./artifacts/*.nupkg
             ./artifacts/*.snupkg
+
+  ci:
+    name: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && 'Draft CI' || 'CI' }}
+    needs: [validation-plan, build-and-test]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check validation results
+        env:
+          SCOPE: ${{ needs.validation-plan.outputs.scope }}
+          PLAN_RESULT: ${{ needs.validation-plan.result }}
+          BUILD_RESULT: ${{ needs.build-and-test.result }}
+        run: |
+          if [ "$PLAN_RESULT" != "success" ]; then exit 1; fi
+          if [ "$BUILD_RESULT" = "failure" ] || [ "$BUILD_RESULT" = "cancelled" ]; then exit 1; fi
+          if [ "$SCOPE" = "full" ] && [ "$BUILD_RESULT" != "success" ]; then exit 1; fi

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -1,0 +1,126 @@
+name: Review policy evaluator
+run-name: "Review policy for #${{ github.event.pull_request.number }} at ${{ github.event.pull_request.head.sha }}"
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: review-policy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    name: Evaluate review policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      REVIEW_POLICY: ${{ vars.GENESIS_REVIEW_POLICY || 'none' }}
+    steps:
+      - name: Publish review policy check
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pull_request="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER")"
+          head_sha="$(jq -r '.head.sha' <<<"$pull_request")"
+          author_login="$(jq -r '.user.login' <<<"$pull_request")"
+          author_type="$(jq -r '.user.type' <<<"$pull_request")"
+          is_draft="$(jq -r '.draft' <<<"$pull_request")"
+          conclusion=success
+          title='Review policy satisfied'
+          summary='No author-specific review is required.'
+
+          case "$REVIEW_POLICY" in
+            none)
+              ;;
+            copilot-one-approval)
+              if [ "$author_login" = 'Copilot' ] && [ "$author_type" = 'Bot' ]; then
+                if [ "$is_draft" = 'true' ]; then
+                  summary='Copilot review is enforced when this pull request becomes ready.'
+                else
+                  reviews="$(
+                    gh api \
+                      --paginate \
+                      --slurp \
+                      "repos/$GH_REPO/pulls/$PR_NUMBER/reviews?per_page=100" |
+                      jq '[.[][]]'
+                  )"
+                  approval_count="$(
+                    jq \
+                      --arg sha "$head_sha" '
+                        sort_by(.submitted_at // "")
+                        | reduce .[] as $review (
+                            {};
+                            .[$review.user.login] = $review
+                          )
+                        | [
+                            .[]
+                            | select(
+                                .state == "APPROVED"
+                                and .commit_id == $sha
+                                and .user.type == "User"
+                                and (
+                                  .author_association == "OWNER"
+                                  or .author_association == "MEMBER"
+                                  or .author_association == "COLLABORATOR"
+                                )
+                              )
+                          ]
+                        | length
+                      ' <<<"$reviews"
+                  )"
+                  if [ "$approval_count" -lt 1 ]; then
+                    conclusion=failure
+                    title='Human approval required'
+                    summary='Copilot-authored ready pull requests require an OWNER, MEMBER, or COLLABORATOR approval on the current head SHA.'
+                  else
+                    summary='A trusted human approved the current Copilot-authored head SHA.'
+                  fi
+                fi
+              fi
+              ;;
+            *)
+              conclusion=failure
+              title='Unsupported review policy'
+              summary="GENESIS_REVIEW_POLICY '$REVIEW_POLICY' is not supported."
+              ;;
+          esac
+
+          jq -n \
+            --arg name 'Review policy' \
+            --arg head_sha "$head_sha" \
+            --arg conclusion "$conclusion" \
+            --arg title "$title" \
+            --arg summary "$summary" '
+              {
+                name: $name,
+                head_sha: $head_sha,
+                status: "completed",
+                conclusion: $conclusion,
+                output: {
+                  title: $title,
+                  summary: $summary
+                }
+              }
+            ' |
+            gh api \
+              --method POST \
+              "repos/$GH_REPO/check-runs" \
+              --input - >/dev/null
+
+          if [ "$conclusion" != 'success' ]; then
+            echo "::error::$summary"
+            exit 1
+          fi

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,39 @@
+name: PR title
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  title:
+    name: PR title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      TITLE_MAX_LENGTH: '72'
+      TITLE_PATTERN: '^(feat|fix|docs|refactor|test|style|build|ci|chore|perf|revert)(\([a-z0-9][a-z0-9._/-]*\))?!?: .+$'
+    steps:
+      - name: Validate conventional title
+        shell: bash
+        run: |
+          if [[ "$PR_TITLE" == *$'\n'* || "$PR_TITLE" == *$'\r'* ]]; then
+            echo "::error::Pull request title must be a single line."
+            exit 1
+          fi
+
+          if (( ${#PR_TITLE} > TITLE_MAX_LENGTH )); then
+            echo "::error::Pull request title is ${#PR_TITLE} characters; maximum is $TITLE_MAX_LENGTH."
+            exit 1
+          fi
+
+          if [[ ! "$PR_TITLE" =~ $TITLE_PATTERN ]]; then
+            echo "::error::Use a conventional title such as 'feat(scope): description'."
+            exit 1
+          fi
+
+          echo "Conventional pull request title is valid."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,48 @@ After the commit succeeds, share with the user:
 
 Do not say "all tests pass" — show the numbers.
 
+## Pull Request Delivery
+
+- Work and local checkpoint commits belong on feature branches. The existing
+  commit assessment and acknowledgment workflow above remains mandatory. Each
+  clone must activate the repository hook with
+  `git config core.hooksPath .githooks` and
+  `git config genesis.defaultBranch master`. With that local configuration
+  active, `.githooks/pre-push` blocks updates or deletion of `master`; deliver
+  changes through pull requests.
+- Run targeted checks while iterating and the full repository validation before
+  delivery. This public repository uses GitHub-hosted runners; no self-hosted
+  runner route is declared in `.github/genesis-delivery.json`.
+- "Open a PR" and "publish a PR" mean ready for review. "Open a draft PR" and
+  "open a PR so I can review" mean draft. Agent-initiated PRs default to draft
+  unless the user explicitly requests a ready PR.
+- Draft pull requests publish `Draft CI` without the full build/test/package
+  job. Moving a pull request to ready starts fresh full validation and publishes
+  the stable required `CI` check.
+- When `GENESIS_REVIEW_POLICY=copilot-one-approval`, a ready Copilot-authored
+  pull request requires one OWNER, MEMBER, or COLLABORATOR approval on its
+  current head SHA. A later Copilot push invalidates the prior approval.
+- In this public repository, workflows from every external fork require
+  explicit maintainer approval before execution. Approval authorizes the entire
+  proposed workflow, including runner selection; the current CI routes all
+  pull requests to GitHub-hosted runners.
+- Pull request titles must use conventional commit semantics and remain at most
+  72 characters. Squash merging uses the PR title as the default-branch commit
+  subject and the PR body as the commit message.
+- After the migration is merged and remote activation is separately approved,
+  protected native auto-merge is the delivery lane. Do not apply or weaken
+  repository settings from a migration branch.
+
+Before opening a ready PR, publishing a draft, or pushing more commits to an
+already-ready PR:
+
+1. Confirm the PR title follows the required conventional format.
+2. Record validation evidence and assess omitted behavior, implementation gaps,
+   failing or missing tests, technical debt, missing coverage, weak assertions,
+   and assumptions.
+3. Fix every high-severity issue or keep the PR in draft. Disclose remaining
+   medium- and low-severity findings in the PR body.
+
 ## Out of Scope
 
 <!-- What should NOT be changed or touched without explicit approval. -->

--- a/scripts/delivery/Configure-GitHubDelivery.ps1
+++ b/scripts/delivery/Configure-GitHubDelivery.ps1
@@ -1,0 +1,452 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Plans or configures PR-first GitHub delivery for a generated project.
+
+.DESCRIPTION
+    Reads `.github/genesis-delivery.json`, probes repository settings and branch
+    protection capability, active default-branch rules, and existing protection,
+    then selects native protected auto-merge or the private exact-SHA
+    workflow-run lane.
+
+    The default is plan-only. `-Apply` is required for GitHub writes. This
+    script never commits, pushes, opens a pull request, or merges. Active
+    rulesets and incompatible existing protection require manual reconciliation.
+
+.PARAMETER ProjectRoot
+    Generated project root. Defaults to the current directory.
+
+.PARAMETER Repository
+    Optional `owner/repository`. Defaults to the current gh repository.
+
+.PARAMETER DeliveryMode
+    Auto, Native, or WorkflowRun. Auto selects Native whenever protection is
+    available and WorkflowRun only for the known private-plan denial.
+
+.PARAMETER CheckSha
+    Commit whose check runs establish the required GitHub check contexts.
+    Defaults to the remote default branch tip.
+
+.PARAMETER Apply
+    Apply the planned GitHub settings. Without this switch, no writes occur.
+
+.PARAMETER AllowUnprotectedPrivate
+    Required with `-Apply` when WorkflowRun is selected.
+
+.PARAMETER ReviewPolicy
+    None, or CopilotOneApproval. CopilotOneApproval requires one trusted human
+    approval on the current SHA before a ready Copilot-authored PR can merge.
+
+.PARAMETER SnapshotPath
+    Optional offline repository snapshot used by Genesis contract tests.
+
+.PARAMETER GhCommand
+    gh executable path. Defaults to `gh`.
+
+.EXAMPLE
+    ./scripts/delivery/Configure-GitHubDelivery.ps1
+
+.EXAMPLE
+    ./scripts/delivery/Configure-GitHubDelivery.ps1 -Apply
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$ProjectRoot = (Get-Location).Path,
+    [string]$Repository,
+    [ValidateSet('Auto', 'Native', 'WorkflowRun')]
+    [string]$DeliveryMode = 'Auto',
+    [string]$CheckSha,
+    [switch]$Apply,
+    [switch]$AllowUnprotectedPrivate,
+    [ValidateSet('None', 'CopilotOneApproval')]
+    [string]$ReviewPolicy = 'None',
+    [string]$SnapshotPath,
+    [string]$GhCommand = 'gh'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ProjectRoot = (Resolve-Path $ProjectRoot).Path
+$contractPath = Join-Path $ProjectRoot '.github' 'genesis-delivery.json'
+$installerPath = Join-Path $ProjectRoot 'scripts' 'delivery' 'Install-PrivateAutoMerge.ps1'
+
+if (-not (Test-Path $contractPath)) {
+    Write-Error "Delivery contract not found at '$contractPath'."
+}
+
+$contract = Get-Content $contractPath -Raw | ConvertFrom-Json
+$requiredChecks = @($contract.requiredChecks | ForEach-Object { [string]$_ })
+$draftMode =
+    if (@($contract.runnerProfiles).Count -gt 0) {
+        [string]$contract.draftValidation.pitcrewDefault
+    } else {
+        [string]$contract.draftValidation.hostedDefault
+    }
+
+function Invoke-GhJson {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$Arguments
+    )
+
+    $output = & $GhCommand @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+    }
+    if ([string]::IsNullOrWhiteSpace(($output -join "`n"))) {
+        return $null
+    }
+    return (($output -join "`n") | ConvertFrom-Json)
+}
+
+function Get-LiveSnapshot {
+    & $GhCommand auth status *> $null
+    if ($LASTEXITCODE -ne 0) {
+        throw 'GitHub CLI authentication is required. Run gh auth login.'
+    }
+
+    $resolvedRepository =
+        if ([string]::IsNullOrWhiteSpace($Repository)) {
+            $repoView = Invoke-GhJson -Arguments @(
+                'repo', 'view', '--json', 'nameWithOwner')
+            [string]$repoView.nameWithOwner
+        } else {
+            $Repository
+        }
+    if ($resolvedRepository -notmatch '^[^/]+/[^/]+$') {
+        throw "Repository '$resolvedRepository' must be owner/name."
+    }
+
+    $repositoryState = Invoke-GhJson -Arguments @(
+        'api', '-H', 'X-GitHub-Api-Version: 2026-03-10',
+        "repos/$resolvedRepository")
+    $defaultBranch = [string]$repositoryState.default_branch
+    $branchSha =
+        if ([string]::IsNullOrWhiteSpace($CheckSha)) {
+            $commit = Invoke-GhJson -Arguments @(
+                'api', '-H', 'X-GitHub-Api-Version: 2026-03-10',
+                "repos/$resolvedRepository/commits/$defaultBranch")
+            [string]$commit.sha
+        } else {
+            $CheckSha
+        }
+
+    $protectionStatus = 'unknown'
+    $protection = $null
+    $protectionOutput = & $GhCommand api `
+        -H 'X-GitHub-Api-Version: 2026-03-10' `
+        "repos/$resolvedRepository/branches/$defaultBranch/protection" 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $protectionStatus = 'protected'
+        $protection = ($protectionOutput -join "`n") | ConvertFrom-Json
+    } else {
+        $message = $protectionOutput -join "`n"
+        if ($message -match 'HTTP 404') {
+            $protectionStatus = 'available-unprotected'
+        } elseif (
+            [bool]$repositoryState.private -and
+            $message -match '(?i)upgrade.*pro|make this repository public') {
+            $protectionStatus = 'unavailable-private-plan'
+        } else {
+            throw "Unable to determine branch protection capability: $message"
+        }
+    }
+
+    $activeRulesStatus = 'available'
+    $activeRules = @()
+    $activeRulesOutput = & $GhCommand api --paginate --slurp `
+        -H 'X-GitHub-Api-Version: 2026-03-10' `
+        "repos/$resolvedRepository/rules/branches/${defaultBranch}?per_page=100" 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $activeRulePages = ($activeRulesOutput -join "`n") | ConvertFrom-Json
+        $activeRules = @(
+            foreach ($page in @($activeRulePages)) {
+                @($page)
+            }
+        )
+    } else {
+        $message = $activeRulesOutput -join "`n"
+        if (
+            [bool]$repositoryState.private -and
+            $message -match '(?i)upgrade.*pro|make this repository public'
+        ) {
+            $activeRulesStatus = 'unavailable-private-plan'
+        } else {
+            throw "Unable to inspect active default-branch rules: $message"
+        }
+    }
+
+    $checkRuns = Invoke-GhJson -Arguments @(
+        'api', '--paginate', '--slurp',
+        "repos/$resolvedRepository/commits/$branchSha/check-runs?filter=latest&per_page=100")
+    $flattenedChecks = @(
+        foreach ($page in @($checkRuns)) {
+            @($page.check_runs)
+        }
+    )
+
+    $privateWorkflowPresent = $false
+    $workflowOutput = & $GhCommand api `
+        -H 'X-GitHub-Api-Version: 2026-03-10' `
+        "repos/$resolvedRepository/contents/.github/workflows/private-auto-merge.yml?ref=$defaultBranch" 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $privateWorkflowPresent = $true
+    } elseif (($workflowOutput -join "`n") -notmatch 'HTTP 404') {
+        throw "Unable to inspect private auto-merge workflow: $($workflowOutput -join "`n")"
+    }
+
+    return [PSCustomObject]@{
+        repository             = $resolvedRepository
+        visibility             = [string]$repositoryState.visibility
+        private                = [bool]$repositoryState.private
+        defaultBranch          = $defaultBranch
+        checkSha               = $branchSha
+        protectionStatus       = $protectionStatus
+        protection             = $protection
+        activeRulesStatus      = $activeRulesStatus
+        activeRules            = @($activeRules)
+        checkRuns              = @($flattenedChecks)
+        privateWorkflowPresent = $privateWorkflowPresent
+    }
+}
+
+$snapshot =
+    if ([string]::IsNullOrWhiteSpace($SnapshotPath)) {
+        Get-LiveSnapshot
+    } else {
+        Get-Content (Resolve-Path $SnapshotPath) -Raw | ConvertFrom-Json
+    }
+
+if ([string]::IsNullOrWhiteSpace($Repository)) {
+    $Repository = [string]$snapshot.repository
+}
+
+$selectedMode =
+    if ($DeliveryMode -ne 'Auto') {
+        $DeliveryMode
+    } elseif ([string]$snapshot.protectionStatus -eq 'unavailable-private-plan') {
+        'WorkflowRun'
+    } else {
+        'Native'
+    }
+
+if ($selectedMode -eq 'WorkflowRun' -and -not [bool]$snapshot.private) {
+    throw 'WorkflowRun delivery is only supported for private repositories.'
+}
+if ($selectedMode -eq 'Native' -and [string]$snapshot.protectionStatus -eq 'unavailable-private-plan') {
+    throw 'Native delivery was requested but branch protection is unavailable for this private repository.'
+}
+
+$successfulCheckNames = @(
+    @($snapshot.checkRuns) |
+        Where-Object { [string]$_.conclusion -eq 'success' } |
+        ForEach-Object { [string]$_.name } |
+        Sort-Object -Unique
+)
+$missingChecks = @($requiredChecks | Where-Object { $_ -notin $successfulCheckNames })
+
+$operations = [System.Collections.Generic.List[string]]::new()
+$status = 'ready'
+$nextAction = $null
+$activeRules = @($snapshot.activeRules)
+
+if ($activeRules.Count -gt 0) {
+    $status = 'manual'
+    $nextAction = 'Active repository or inherited rulesets apply to the default branch. Reconcile them manually; Genesis will not mutate overlapping policy.'
+} elseif ($selectedMode -eq 'Native' -and $missingChecks.Count -gt 0) {
+    $status = 'deferred'
+    $nextAction = "Run the required workflows, then rerun with -CheckSha <sha>. Missing: $($missingChecks -join ', ')."
+} elseif ($selectedMode -eq 'WorkflowRun' -and -not [bool]$snapshot.privateWorkflowPresent) {
+    $status = 'deferred'
+    $nextAction = 'Install and merge .github/workflows/private-auto-merge.yml, then rerun.'
+    if (Test-Path $installerPath) {
+        if ($Apply) {
+            & $installerPath -ProjectRoot $ProjectRoot -Confirm:$false | Out-Null
+        } else {
+            & $installerPath -ProjectRoot $ProjectRoot -WhatIf | Out-Null
+        }
+    }
+}
+
+if ($status -eq 'ready') {
+    $reviewPolicyValue =
+        if ($ReviewPolicy -eq 'CopilotOneApproval') {
+            'copilot-one-approval'
+        } else {
+            'none'
+        }
+    $operations.Add('Configure squash-only repository merge settings') | Out-Null
+    $operations.Add('Set read-only Actions workflow permissions') | Out-Null
+    if (-not [bool]$snapshot.private) {
+        $operations.Add('Require workflow approval for all external contributors') | Out-Null
+    }
+    $operations.Add("Set CI_DRAFT_MODE=$draftMode") | Out-Null
+    $operations.Add("Set GENESIS_REVIEW_POLICY=$reviewPolicyValue") | Out-Null
+    if ($selectedMode -eq 'Native') {
+        if ([string]$snapshot.protectionStatus -eq 'protected') {
+            $existingChecks = @($snapshot.protection.required_status_checks.checks)
+            $missingProtectionChecks = @(
+                $requiredChecks |
+                    Where-Object {
+                        $requiredCheck = $_
+                        -not ($existingChecks | Where-Object {
+                            [string]$_.context -ceq $requiredCheck -and
+                            [int]$_.app_id -eq 15368
+                        })
+                    }
+            )
+            $reviewBypasses = $snapshot.protection.required_pull_request_reviews.bypass_pull_request_allowances
+            $reviewBypassActors = @(
+                if ($null -ne $reviewBypasses) {
+                    @($reviewBypasses.users) | Where-Object { $null -ne $_ }
+                    @($reviewBypasses.teams) | Where-Object { $null -ne $_ }
+                    @($reviewBypasses.apps) | Where-Object { $null -ne $_ }
+                }
+            )
+            $hasReviewBypasses = $reviewBypassActors.Count -gt 0
+            $compatibleProtection = (
+                $missingProtectionChecks.Count -eq 0 -and
+                [bool]$snapshot.protection.required_status_checks.strict -and
+                [bool]$snapshot.protection.enforce_admins.enabled -and
+                $null -ne $snapshot.protection.required_pull_request_reviews -and
+                -not $hasReviewBypasses -and
+                [bool]$snapshot.protection.required_conversation_resolution.enabled -and
+                -not [bool]$snapshot.protection.allow_force_pushes.enabled -and
+                -not [bool]$snapshot.protection.allow_deletions.enabled
+            )
+            if (-not $compatibleProtection) {
+                throw 'Existing branch protection differs from the Genesis safety contract; update it manually rather than allowing Genesis to overwrite it.'
+            }
+            $operations.Add('Keep existing compatible branch protection') | Out-Null
+        } else {
+            $operations.Add('Create strict default-branch protection with required checks') | Out-Null
+        }
+        $operations.Add('Enable native repository auto-merge') | Out-Null
+        $operations.Add('Set GENESIS_DELIVERY_MODEL=native') | Out-Null
+    } else {
+        $operations.Add('Set GENESIS_DELIVERY_MODEL=workflow-run') | Out-Null
+    }
+}
+
+$result = [ordered]@{
+    schemaVersion    = 1
+    repository       = [string]$snapshot.repository
+    defaultBranch    = [string]$snapshot.defaultBranch
+    visibility       = [string]$snapshot.visibility
+    selectedMode     = $selectedMode
+    status           = $status
+    requiredChecks   = @($requiredChecks)
+    missingChecks    = @($missingChecks)
+    operations       = @($operations)
+    draftMode        = $draftMode
+    reviewPolicy     = $ReviewPolicy
+    activeRulesStatus = [string]$snapshot.activeRulesStatus
+    activeRules      = @($activeRules)
+    nextAction       = $nextAction
+}
+
+if (-not $Apply -or $status -ne 'ready') {
+    [PSCustomObject]$result
+    return
+}
+if ($selectedMode -eq 'WorkflowRun' -and -not $AllowUnprotectedPrivate) {
+    throw '-AllowUnprotectedPrivate is required to apply workflow-run delivery.'
+}
+if (-not $PSCmdlet.ShouldProcess(
+    $Repository,
+    "Apply Genesis $selectedMode delivery settings, variables, and local default-branch configuration"
+)) {
+    $result.status = if ($WhatIfPreference) { 'what-if' } else { 'cancelled' }
+    [PSCustomObject]$result
+    return
+}
+
+Write-Host "[1/3] Applying squash-only repository settings"
+$autoMergeValue = if ($selectedMode -eq 'Native') { 'true' } else { 'false' }
+& $GhCommand api --method PATCH `
+    -H 'X-GitHub-Api-Version: 2026-03-10' `
+    "repos/$Repository" `
+    -F allow_squash_merge=true `
+    -F allow_merge_commit=false `
+    -F allow_rebase_merge=false `
+    -F "allow_auto_merge=$autoMergeValue" `
+    -F delete_branch_on_merge=true `
+    -f squash_merge_commit_title=PR_TITLE `
+    -f squash_merge_commit_message=PR_BODY *> $null
+if ($LASTEXITCODE -ne 0) { throw 'Failed to configure repository merge settings.' }
+
+Write-Host "[2/3] Applying delivery model '$selectedMode'"
+if ($selectedMode -eq 'Native' -and [string]$snapshot.protectionStatus -ne 'protected') {
+    $checks = @(
+        $requiredChecks | ForEach-Object {
+            [ordered]@{ context = $_; app_id = 15368 }
+        }
+    )
+    $protectionBody = [ordered]@{
+        required_status_checks = [ordered]@{ strict = $true; checks = $checks }
+        enforce_admins = $true
+        required_pull_request_reviews = [ordered]@{
+            dismiss_stale_reviews = $false
+            require_code_owner_reviews = $false
+            required_approving_review_count = 0
+            require_last_push_approval = $false
+        }
+        restrictions = $null
+        required_linear_history = $false
+        allow_force_pushes = $false
+        allow_deletions = $false
+        block_creations = $false
+        required_conversation_resolution = $true
+        lock_branch = $false
+        allow_fork_syncing = $false
+    }
+    $protectionBody | ConvertTo-Json -Depth 8 -Compress |
+        & $GhCommand api --method PUT `
+            -H 'X-GitHub-Api-Version: 2026-03-10' `
+            "repos/$Repository/branches/$($snapshot.defaultBranch)/protection" `
+            --input - *> $null
+    if ($LASTEXITCODE -ne 0) { throw 'Failed to configure branch protection.' }
+}
+
+$workflowPermissionsBody = [ordered]@{
+    default_workflow_permissions = 'read'
+    can_approve_pull_request_reviews = $false
+}
+$workflowPermissionsBody | ConvertTo-Json -Compress |
+    & $GhCommand api --method PUT `
+        -H 'X-GitHub-Api-Version: 2026-03-10' `
+        "repos/$Repository/actions/permissions/workflow" `
+        --input - *> $null
+if ($LASTEXITCODE -ne 0) { throw 'Failed to configure Actions workflow permissions.' }
+
+if (-not [bool]$snapshot.private) {
+    [ordered]@{ approval_policy = 'all_external_contributors' } |
+        ConvertTo-Json -Compress |
+        & $GhCommand api --method PUT `
+            -H 'X-GitHub-Api-Version: 2026-03-10' `
+            "repos/$Repository/actions/permissions/fork-pr-contributor-approval" `
+            --input - *> $null
+    if ($LASTEXITCODE -ne 0) { throw 'Failed to configure public fork workflow approval.' }
+}
+
+$modelValue = if ($selectedMode -eq 'Native') { 'native' } else { 'workflow-run' }
+& $GhCommand variable set GENESIS_DELIVERY_MODEL `
+    --repo $Repository `
+    --body $modelValue *> $null
+if ($LASTEXITCODE -ne 0) { throw 'Failed to set GENESIS_DELIVERY_MODEL.' }
+
+& $GhCommand variable set GENESIS_REVIEW_POLICY `
+    --repo $Repository `
+    --body $reviewPolicyValue *> $null
+if ($LASTEXITCODE -ne 0) { throw 'Failed to set GENESIS_REVIEW_POLICY.' }
+
+& $GhCommand variable set CI_DRAFT_MODE `
+    --repo $Repository `
+    --body $draftMode *> $null
+if ($LASTEXITCODE -ne 0) { throw 'Failed to set CI_DRAFT_MODE.' }
+
+Write-Host "[3/3] Recording default branch locally"
+git -C $ProjectRoot config genesis.defaultBranch ([string]$snapshot.defaultBranch)
+
+$result.status = 'applied'
+[PSCustomObject]$result

--- a/scripts/delivery/Install-PrivateAutoMerge.ps1
+++ b/scripts/delivery/Install-PrivateAutoMerge.ps1
@@ -1,0 +1,132 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Installs the generated private-repository exact-SHA auto-merge workflow.
+
+.DESCRIPTION
+    Reads `.github/genesis-delivery.json`, discovers the workflow display names
+    that own required merge gates, renders the inactive Genesis workflow template,
+    and writes `.github/workflows/private-auto-merge.yml`.
+
+    This script only edits the local working tree. It never commits, pushes,
+    opens a pull request, changes GitHub settings, or merges.
+
+.PARAMETER ProjectRoot
+    Generated project root. Defaults to the current directory.
+
+.PARAMETER Force
+    Replace an existing different workflow. Without this switch, a differing
+    target is treated as an error.
+
+.EXAMPLE
+    ./scripts/delivery/Install-PrivateAutoMerge.ps1
+
+.EXAMPLE
+    ./scripts/delivery/Install-PrivateAutoMerge.ps1 -WhatIf
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$ProjectRoot = (Get-Location).Path,
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ProjectRoot = (Resolve-Path $ProjectRoot).Path
+$contractPath = Join-Path $ProjectRoot '.github' 'genesis-delivery.json'
+$templatePath = Join-Path $ProjectRoot '.genesis' 'delivery' 'private-auto-merge.yml'
+$targetPath = Join-Path $ProjectRoot '.github' 'workflows' 'private-auto-merge.yml'
+
+if (-not (Test-Path $contractPath)) {
+    Write-Error "Delivery contract not found at '$contractPath'."
+}
+if (-not (Test-Path $templatePath)) {
+    Write-Error "Private auto-merge template not found at '$templatePath'."
+}
+
+Write-Host "[1/3] Reading delivery contract"
+$contract = Get-Content $contractPath -Raw | ConvertFrom-Json
+$workflowNames = [System.Collections.Generic.List[string]]::new()
+$seen = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::Ordinal)
+
+function Add-WorkflowName {
+    param([string]$Name)
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        Write-Error 'A required workflow has an empty display name.'
+    }
+    if ($seen.Add($Name)) {
+        $workflowNames.Add($Name) | Out-Null
+    }
+}
+
+Add-WorkflowName ([string]$contract.ciWorkflow)
+Add-WorkflowName 'PR title'
+Add-WorkflowName 'Review policy evaluator'
+
+foreach ($workflow in @($contract.componentWorkflows)) {
+    if (@($workflow.roles) -notcontains 'merge-gate') {
+        continue
+    }
+
+    $workflowPath = Join-Path $ProjectRoot ([string]$workflow.path)
+    if (-not (Test-Path $workflowPath)) {
+        Write-Error "Required component workflow not found at '$workflowPath'."
+    }
+    $workflowText = Get-Content $workflowPath -Raw
+    $nameMatch = [regex]::Match($workflowText, '(?m)^name:\s*(.+?)\r?$')
+    if (-not $nameMatch.Success) {
+        Write-Error "Required component workflow '$workflowPath' has no top-level name."
+    }
+    Add-WorkflowName ($nameMatch.Groups[1].Value.Trim().Trim('"', "'"))
+}
+
+Write-Host "[2/3] Rendering workflow listeners: $($workflowNames -join ', ')"
+$template = Get-Content $templatePath -Raw
+$marker = '      # __GENESIS_WORKFLOW_NAMES__'
+if (-not $template.Contains($marker)) {
+    Write-Error "Workflow template marker is missing from '$templatePath'."
+}
+$renderedNames = @(
+    $workflowNames |
+        ForEach-Object {
+            $escapedName = $_.Replace("'", "''")
+            "      - '$escapedName'"
+        }
+) -join "`n"
+$rendered = $template.Replace($marker, $renderedNames)
+
+if (Test-Path $targetPath) {
+    $current = Get-Content $targetPath -Raw
+    if ($current -ceq $rendered) {
+        Write-Host "[3/3] Workflow already current: $targetPath"
+        return [PSCustomObject]@{
+            Path      = $targetPath
+            Changed   = $false
+            Workflows = @($workflowNames)
+        }
+    }
+    if (-not $Force) {
+        Write-Error "A different workflow already exists at '$targetPath'. Re-run with -Force to replace it."
+    }
+}
+
+$changed = $false
+if ($PSCmdlet.ShouldProcess($targetPath, 'Install private exact-SHA auto-merge workflow')) {
+    $targetDir = Split-Path $targetPath -Parent
+    if (-not (Test-Path $targetDir)) {
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    }
+    [IO.File]::WriteAllText(
+        $targetPath,
+        $rendered,
+        [Text.UTF8Encoding]::new($false))
+    Write-Host "[3/3] Installed workflow: $targetPath"
+    $changed = $true
+}
+
+[PSCustomObject]@{
+    Path      = $targetPath
+    Changed   = $changed
+    Workflows = @($workflowNames)
+}


### PR DESCRIPTION
## Summary

- migrate CI to the current Genesis PR-first NuGet-library lifecycle while preserving restore, build, test, pack, package smoke verification, push validation, caching, and artifact contracts
- add stable `CI`, `PR title`, and `Review policy` governance checks with hosted `ready-only` draft behavior
- install the generated delivery contract/schema, plan-only configurator, inactive private fallback template, and protected-branch pre-push hook
- document PR delivery and per-clone hook activation in `AGENTS.md`
- preserve `.github/workflows/release.yml` byte-for-byte, including tag/manual triggers, NuGet OIDC, secret use, and publication commands

## Validation

- Genesis alignment audit: 47 checks, 0 errors, 0 warnings
- delivery contract validates against the copied schema; all workflow YAML parses successfully
- `dotnet build --no-restore --configuration Release`: 0 warnings, 0 errors
- `dotnet test --no-build --configuration Release`: 824 passed, 0 failed, 1 pre-existing skipped
- `dotnet pack --no-build --configuration Release`: 8 `.nupkg` and 8 `.snupkg`
- installed-package verification passed for TUnit assertions and strongly typed identifiers
- CI scope probe passed for draft, ready, manual subset, subset promotion, and invalid input
- pre-push hook probe passed for empty-remote bootstrap, feature branches, blocked `master` update, and blocked `master` deletion
- exact-SHA cleanup probe passed for deletion, absent ref, advanced ref, denied deletion, and transport failure
- read-only delivery plan selects Native and remains deferred until the new checks exist on `master`

## Observed PR evidence

- draft run: [`Draft CI`](https://github.com/ncosentino/NexusLabs.Framework/actions/runs/30379962641) passed, `build-and-test` skipped, validation planning passed
- ready transition started a fresh run: [`CI`](https://github.com/ncosentino/NexusLabs.Framework/actions/runs/30380026731) and transitional `build-and-test` passed
- conventional [`PR title`](https://github.com/ncosentino/NexusLabs.Framework/actions/runs/30380026922) passed on the ready head
- PR is ready, mergeable, current with `master`, and still governed by the existing `build-and-test` protection until post-merge activation

## Gaps and activation boundary

- no GitHub repository settings are changed by this PR; read-back confirms existing settings remain intact
- remote activation remains pending until this PR is merged and separately approved
- the deterministic Genesis hook falls back to `main` if clone-local configuration is absent; `AGENTS.md` requires every clone to set `core.hooksPath=.githooks` and `genesis.defaultBranch=master`
- no external-fork PR exists in repository history, so fork execution is statically audited but not observed on a real PR
- `Review policy` cannot run on this migration PR because a new `pull_request_target` workflow must first exist on the default branch
- Copilot current-SHA approval and native auto-merge evidence remain post-merge activation scenarios
- the bundled Genesis ReadyFull observer does not classify the current NuGet template's Validation plan job as a preflight; direct check evidence passed and a raw Snapshot was captured instead
- the GitHub UI setting for Copilot-authored workflow approval remains a manual post-merge check

## Delivery states

- **Local migration:** complete
- **Remote activation:** pending after merge and separate approval
- **Observed evidence:** draft and ready CI proven on this PR; external-fork, review-policy, and native-merge scenarios remain unobserved
