### PR TITLE
ci: verify activated Genesis delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ dotnet add package NexusLabs.Data.Sql            # provider-agnostic decorators
 dotnet add package NexusLabs.Data.Sql.MySql      # adds MySql.Data backed factory
 ```
 
+## Pull request delivery
+
+Repository changes are delivered through protected pull requests under the
+Genesis PR-first model. The machine-readable delivery contract is
+`.github/genesis-delivery.json`; contributor and agent guidance is in
+`AGENTS.md`.
+
 Runtime packages target `net10.0`; Roslyn analyzer assemblies target
 `netstandard2.0`. For earlier .NET versions, pin to a 0.1.x of
 `NexusLabs.Framework`.


### PR DESCRIPTION
## Purpose

Materialize the post-merge Genesis check contexts on one exact same-repository PR SHA so native activation can safely replace the transitional required check.

## Change set

- empty commit; no repository files changed
- activation probe only

## Validation

- local build: 0 warnings, 0 errors
- local tests: 824 passed, 0 failed, 1 pre-existing skipped
- activation will not proceed until `CI`, `PR title`, `Review policy`, and transitional `build-and-test` succeed on this exact head

After activation, this PR will be moved draft→ready to rerun policy under the activated variables, armed for native auto-merge, and used to verify automatic head-branch cleanup.
