### PR TITLE
chore(release): prepare v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ preserved at the bottom of this file for reference.
 
 ## [Unreleased]
 
+## [0.2.9] &mdash; 2026-08-01
+
+Adds the `NexusLabs.Testing` package and four `TimeProvider` analyzers. Per
+lockstep versioning, every `NexusLabs.*` package advances to 0.2.9 together;
+`NexusLabs.Testing` enters the line at that version.
+
 ### NexusLabs.Testing
 
 New package. Framework-agnostic test helpers. The initial surface is the `Time`

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
       of the entire monorepo; the release workflow packs + pushes every package
       at the same version.
     -->
-    <Version>0.2.8</Version>
+    <Version>0.2.9</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="!$(MSBuildProjectName.EndsWith('.Tests'))">


### PR DESCRIPTION
## Release 0.2.9

Bumps the lockstep `<Version>` in `Directory.Build.props` and promotes the `[Unreleased]` changelog section to `[0.2.9]`.

Ships the work merged in #36:

- **`NexusLabs.Testing`** &mdash; new package. Framework-agnostic test helpers, opening with the `Time` namespace: `RegistrationObservingTimeProvider`, `AdvanceUntilAsync`, `Wait.UntilAsync`, `WaitOutcome`. It enters the lockstep line at 0.2.9.
- **`NexusLabs.Framework.Analyzers`** &mdash; `NLF0025`&ndash;`NLF0028` covering `TimeProvider` flow, custom time abstractions, and fake-clock `CreateTimer` overrides.

## Why patch rather than minor

Consistent with how this repository has always shipped new analyzer rules: `NLF0011` in 0.2.2, `NLF0015`/`NLF0018` in 0.2.3, `NLF0024` in 0.2.6.

## Validation

- Build: **0 warnings, 0 errors** (full solution rebuild, `TreatWarningsAsErrors` on).
- Tests: **872 total &mdash; 871 passed, 0 failed, 1 skipped.** The skip is the pre-existing flaky multicast-event test, untouched.
- `dotnet pack` emits all **9** packages at 0.2.9, including the new `NexusLabs.Testing.0.2.9.nupkg`.

## Disclosed findings

No high- or medium-severity items.

Low severity: the new rules ship at Warning (`NLF0026` at Info), so a consumer building with `TreatWarningsAsErrors` may see them surface on upgrade. That is the intended behaviour of the rules and matches the precedent above; per-rule opt-out is documented in each `docs/analyzers/NLF002x.md` page.

## After merge

Tag `v0.2.9` on the merge commit to trigger the NuGet Trusted Publishing release workflow.
