### PR TITLE
chore: enable stacked pull request delivery

### DIFF
--- a/.genesis/delivery/private-auto-merge.yml
+++ b/.genesis/delivery/private-auto-merge.yml
@@ -9,7 +9,9 @@ on:
 permissions:
   checks: read
   contents: write
+  issues: write
   pull-requests: write
+  statuses: write
 
 concurrency:
   group: private-auto-merge-${{ github.repository }}
@@ -31,22 +33,131 @@ jobs:
         )
       ) &&
       github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    runs-on: ${{ github.event.repository.private && (vars.REPOSITORY_AUTOMATION_CONTROL_RUNNER || 'repository-automation-capability-unavailable') || (vars.REPOSITORY_AUTOMATION_CONTROL_RUNNER || 'ubuntu-24.04') }}
+    timeout-minutes: 10
     env:
       GH_PROMPT_DISABLED: '1'
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
       GIT_TERMINAL_PROMPT: '0'
       REQUIRED_CHECK_APP_ID: '15368'
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      STATUS_CONTEXT: Auto-merge
       TRIGGER_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
       TRIGGER_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
       TRIGGER_WORKFLOW_PATH: ${{ github.event.workflow_run.path }}
     steps:
-      - name: Merge the exact tested pull request
+      - name: Merge the exact tested pull request or stack
         shell: bash
         run: |
           set -euo pipefail
+
+          gh_api_read() {
+            local output=''
+            local status=0
+            for attempt in 1 2 3 4; do
+              if output="$(gh api "$@" 2>&1)"; then
+                printf '%s\n' "$output"
+                return 0
+              else
+                status=$?
+              fi
+              if [ "$attempt" -lt 4 ]; then
+                echo "::warning::GitHub API read attempt $attempt failed; retrying." >&2
+                sleep "$(( attempt * 5 ))"
+              fi
+            done
+            printf '%s\n' "$output" >&2
+            return "$status"
+          }
+
+          publish_status() {
+            local state="$1"
+            local description="$2"
+            if [ -z "${tested_sha:-}" ]; then
+              return 0
+            fi
+            if ! gh api \
+                --method POST \
+                "repos/$GH_REPO/statuses/$tested_sha" \
+                -f state="$state" \
+                -f context="$STATUS_CONTEXT" \
+                -f description="${description:0:140}" \
+                -f target_url="$RUN_URL" >/dev/null; then
+              echo "::warning::Could not publish the '$STATUS_CONTEXT' status; this reason stays in the workflow log only."
+            fi
+          }
+
+          validate_pull_request() {
+            local pull_request_json="$1"
+            local expected_sha="$2"
+            local expected_number="$3"
+            local current_title
+            local check_runs
+            local required_check
+            local conclusion
+
+            validation_state='success'
+            validation_reason=''
+            current_title="$(jq -r '.title // empty' <<<"$pull_request_json")"
+
+            if [ "$(jq -r '.number' <<<"$pull_request_json")" != "$expected_number" ] ||
+               [ "$(jq -r '.state' <<<"$pull_request_json")" != 'open' ] ||
+               [ "$(jq -r '.draft' <<<"$pull_request_json")" != 'false' ] ||
+               [ "$(jq -r '.head.sha // empty' <<<"$pull_request_json")" != "$expected_sha" ] ||
+               [ "$(jq -r '.head.repo.full_name // empty' <<<"$pull_request_json")" != "$GH_REPO" ] ||
+               [ "$(jq -r '.base.repo.full_name // empty' <<<"$pull_request_json")" != "$GH_REPO" ]; then
+              validation_state='pending'
+              validation_reason="Pull request #$expected_number changed or is still draft."
+              return
+            fi
+
+            if [[ "$current_title" == *$'\n'* || "$current_title" == *$'\r'* ]] ||
+               (( ${#current_title} > title_max_length )) ||
+               [[ ! "$current_title" =~ $title_pattern ]]; then
+              validation_state='failure'
+              validation_reason="Pull request #$expected_number has an invalid conventional title."
+              return
+            fi
+
+            check_runs="$(
+              gh_api_read \
+                --paginate \
+                --slurp \
+                "repos/$GH_REPO/commits/$expected_sha/check-runs?filter=latest&per_page=100" |
+                jq '{check_runs: [.[].check_runs[]]}'
+            )"
+            while IFS= read -r required_check; do
+              conclusion="$(
+                jq -r \
+                  --arg name "$required_check" \
+                  --argjson app_id "$REQUIRED_CHECK_APP_ID" '
+                    [
+                      .check_runs[]
+                      | select(.name == $name and .app.id == $app_id)
+                    ]
+                    | sort_by(.completed_at // .started_at // "")
+                    | reverse
+                    | first
+                    | .conclusion // ""
+                  ' <<<"$check_runs"
+              )"
+              if [ "$conclusion" = 'success' ]; then
+                continue
+              fi
+              case "$conclusion" in
+                failure | timed_out | cancelled | action_required | startup_failure)
+                  validation_state='failure'
+                  validation_reason="Required check '$required_check' for #$expected_number is '$conclusion'."
+                  ;;
+                *)
+                  validation_state='pending'
+                  validation_reason="Required check '$required_check' for #$expected_number has not succeeded yet."
+                  ;;
+              esac
+              return
+            done < <(jq -r '.requiredChecks[]' <<<"$contract")
+          }
 
           tested_sha="$TRIGGER_HEAD_SHA"
           trigger_pr_number=''
@@ -55,192 +166,412 @@ jobs:
               trigger_pr_number="${BASH_REMATCH[1]}"
               tested_sha="${BASH_REMATCH[2]}"
             else
+              publish_status failure "Blocked: the review policy run title did not identify an exact pull request SHA."
               echo "::error::Review policy run title does not identify an exact pull request SHA."
               exit 1
             fi
           fi
 
-          repository="$(gh api "repos/$GH_REPO")"
+          repository="$(gh_api_read "repos/$GH_REPO")"
           default_branch="$(jq -r '.default_branch' <<<"$repository")"
           repository_id="$(jq -r '.id' <<<"$repository")"
           contract="$(
-            gh api \
+            gh_api_read \
               -H 'Accept: application/vnd.github.raw+json' \
               "repos/$GH_REPO/contents/.github/genesis-delivery.json?ref=$default_branch"
           )"
+          if ! jq -e '
+              any(
+                .componentWorkflows[]?;
+                .source == "github-stacked-pr-delivery"
+                and .path == ".github/workflows/pr-base.yml"
+              )
+            ' \
+              <<<"$contract" >/dev/null; then
+            echo "::error::The installed stack-aware merge workflow is not authorized by the generated delivery contract."
+            exit 1
+          fi
 
-          pull_requests="$(
-            gh api "repos/$GH_REPO/commits/$tested_sha/pulls" |
+          title_pattern="$(jq -r '.pullRequestTitle.pattern' <<<"$contract")"
+          title_max_length="$(jq -r '.pullRequestTitle.maxLength' <<<"$contract")"
+          candidates="$(
+            gh_api_read \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/$GH_REPO/commits/$tested_sha/pulls" |
               jq --arg sha "$tested_sha" --arg repo "$GH_REPO" --arg base "$default_branch" '
                 [
                   .[]
                   | select(
                       .state == "open"
-                      and .base.ref == $base
                       and .head.sha == $sha
                       and .head.repo.full_name == $repo
-                      and .draft == false
+                      and (
+                        .base.ref == $base
+                        or (
+                          .stack != null
+                          and .stack.base.ref == $base
+                        )
+                      )
                     )
                 ]
               '
           )"
+          pull_requests="$(jq '[ .[] | select(.draft == false) ]' <<<"$candidates")"
           pull_request_count="$(jq 'length' <<<"$pull_requests")"
 
           if [ "$pull_request_count" -eq 0 ]; then
-            echo "No ready same-repository pull request targets $default_branch at $tested_sha."
+            if [ "$(jq 'length' <<<"$candidates")" -gt 0 ]; then
+              publish_status pending "Waiting: this pull request is a draft. Mark it ready for review to start auto-merge."
+              echo "Pull request at $tested_sha is a draft; leaving it open."
+            else
+              echo "No ready same-repository pull request or stack targets $default_branch at $tested_sha."
+            fi
             exit 0
           fi
           if [ "$pull_request_count" -ne 1 ]; then
+            publish_status failure "Blocked: $pull_request_count pull requests match the tested commit, so auto-merge cannot choose one."
             echo "::error::$pull_request_count pull requests match tested commit $tested_sha."
             exit 1
           fi
 
           pull_request_number="$(jq -r '.[0].number' <<<"$pull_requests")"
           if [ -n "$trigger_pr_number" ] && [ "$pull_request_number" != "$trigger_pr_number" ]; then
-            echo "::error::Review policy run identified pull request $trigger_pr_number, but commit lookup found $pull_request_number."
+            publish_status failure "Blocked: the review policy run and commit lookup disagree about the tested pull request."
+            echo "::error::Review policy identified #$trigger_pr_number, but commit lookup found #$pull_request_number."
             exit 1
           fi
-          pull_request="$(gh api "repos/$GH_REPO/pulls/$pull_request_number")"
-          current_sha="$(jq -r '.head.sha' <<<"$pull_request")"
-          current_base="$(jq -r '.base.ref' <<<"$pull_request")"
-          current_repo="$(jq -r '.head.repo.full_name' <<<"$pull_request")"
+
+          pull_request="$(
+            gh_api_read \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/$GH_REPO/pulls/$pull_request_number"
+          )"
+          current_sha="$(jq -r '.head.sha // empty' <<<"$pull_request")"
+          current_base="$(jq -r '.base.ref // empty' <<<"$pull_request")"
+          current_repo="$(jq -r '.head.repo.full_name // empty' <<<"$pull_request")"
           head_ref="$(jq -r '.head.ref // empty' <<<"$pull_request")"
           head_repo_id="$(jq -r '.head.repo.id // empty' <<<"$pull_request")"
           base_repo_id="$(jq -r '.base.repo.id // empty' <<<"$pull_request")"
-          current_state="$(jq -r '.state' <<<"$pull_request")"
-          current_draft="$(jq -r '.draft' <<<"$pull_request")"
-          current_title="$(jq -r '.title' <<<"$pull_request")"
+          stack_number="$(jq -r '.stack.number // empty' <<<"$pull_request")"
+          stack_base_ref="$(jq -r '.stack.base.ref // empty' <<<"$pull_request")"
 
-          if [ "$current_state" != "open" ] ||
-             [ "$current_draft" != "false" ] ||
-             [ "$current_base" != "$default_branch" ] ||
+          if [ "$(jq -r '.state' <<<"$pull_request")" != 'open' ] ||
+             [ "$(jq -r '.draft' <<<"$pull_request")" != 'false' ] ||
              [ "$current_repo" != "$GH_REPO" ] ||
              [ "$current_sha" != "$tested_sha" ]; then
-            echo "Pull request $pull_request_number changed after validation; leaving it open."
+            publish_status pending "Waiting: the pull request changed after validation. The next completed run re-evaluates it."
+            echo "Pull request #$pull_request_number changed after validation; leaving it open."
             exit 0
           fi
           if [ -z "$head_ref" ] ||
              [ "$head_repo_id" != "$repository_id" ] ||
              [ "$base_repo_id" != "$repository_id" ] ||
              [ "$head_ref" = "$default_branch" ]; then
-            echo "::error::Pull request $pull_request_number does not have a deletable same-repository head branch."
-            exit 1
-          fi
-          full_ref="refs/heads/$head_ref"
-          git check-ref-format --branch "$head_ref" >/dev/null
-          git check-ref-format "$full_ref" >/dev/null
-
-          title_pattern="$(jq -r '.pullRequestTitle.pattern' <<<"$contract")"
-          title_max_length="$(jq -r '.pullRequestTitle.maxLength' <<<"$contract")"
-          if [[ "$current_title" == *$'\n'* || "$current_title" == *$'\r'* ]] ||
-             (( ${#current_title} > title_max_length )) ||
-             [[ ! "$current_title" =~ $title_pattern ]]; then
-            echo "::error::Pull request $pull_request_number has an invalid conventional title."
+            publish_status failure "Blocked: this pull request does not have a same-repository feature branch."
+            echo "::error::Pull request #$pull_request_number does not have a same-repository feature branch."
             exit 1
           fi
 
-          check_runs="$(
-            gh api \
-              --paginate \
-              --slurp \
-              "repos/$GH_REPO/commits/$tested_sha/check-runs?filter=latest&per_page=100" |
-              jq '{check_runs: [.[].check_runs[]]}'
-          )"
-          while IFS= read -r required_check; do
-            conclusion="$(
-              jq -r \
-                --arg name "$required_check" \
-                --argjson app_id "$REQUIRED_CHECK_APP_ID" '
-                [
-                  .check_runs[]
-                  | select(.name == $name and .app.id == $app_id)
-                ] | first | .conclusion // ""
-              ' <<<"$check_runs"
+          if [ -z "$stack_number" ]; then
+            if [ "$current_base" != "$default_branch" ]; then
+              publish_status failure "Blocked: non-default-base pull request has no GitHub stack metadata."
+              echo "::error::Pull request #$pull_request_number targets '$current_base' without native stack membership."
+              exit 1
+            fi
+
+            validate_pull_request "$pull_request" "$tested_sha" "$pull_request_number"
+            case "$validation_state" in
+              success)
+                ;;
+              failure)
+                publish_status failure "Blocked: $validation_reason"
+                echo "::error::$validation_reason"
+                exit 0
+                ;;
+              *)
+                publish_status pending "Waiting: $validation_reason"
+                echo "$validation_reason"
+                exit 0
+                ;;
+            esac
+
+            current_base_sha="$(gh_api_read "repos/$GH_REPO/commits/$default_branch" --jq '.sha')"
+            comparison_status="$(
+              gh_api_read \
+                "repos/$GH_REPO/compare/$current_base_sha...$tested_sha" \
+                --jq '.status'
             )"
-            if [ "$conclusion" != "success" ]; then
-              echo "Required check '$required_check' is '$conclusion'; leaving pull request open."
+            if [ "$comparison_status" != 'ahead' ] && [ "$comparison_status" != 'identical' ]; then
+              publish_status failure "Blocked: this branch does not contain the current $default_branch tip."
+              echo "Pull request #$pull_request_number does not contain current $default_branch commit $current_base_sha."
               exit 0
             fi
-          done < <(jq -r '.requiredChecks[]' <<<"$contract")
 
-          current_base_sha="$(gh api "repos/$GH_REPO/commits/$default_branch" --jq '.sha')"
-          comparison_status="$(
-            gh api "repos/$GH_REPO/compare/$current_base_sha...$tested_sha" --jq '.status'
-          )"
-          if [ "$comparison_status" != 'ahead' ] && [ "$comparison_status" != 'identical' ]; then
-            echo "Pull request $pull_request_number does not contain current $default_branch commit $current_base_sha; update the branch and rerun CI."
+            set +e
+            merge_response="$(
+              gh api \
+                --method PUT \
+                "repos/$GH_REPO/pulls/$pull_request_number/merge" \
+                -f merge_method=squash \
+                -f sha="$tested_sha" 2>&1
+            )"
+            merge_call_status=$?
+            set -e
+            if (( merge_call_status != 0 )); then
+              publish_status failure "Blocked: merge returned no authoritative response; inspect this run before retrying."
+              printf '%s\n' "$merge_response" >&2
+              exit 1
+            fi
+            if [ "$(jq -r '.merged' <<<"$merge_response")" != 'true' ]; then
+              message="$(jq -r '.message // "GitHub declined the merge."' <<<"$merge_response")"
+              publish_status failure "Blocked: GitHub declined the merge: $message"
+              echo "::error::Pull request #$pull_request_number was not merged: $message"
+              exit 1
+            fi
+
+            merge_sha="$(jq -r '.sha' <<<"$merge_response")"
+            publish_status success "Merged as ${merge_sha:0:7}."
+            echo "Merged pull request #$pull_request_number at $merge_sha."
+
+            full_ref="refs/heads/$head_ref"
+            git check-ref-format --branch "$head_ref" >/dev/null
+            git check-ref-format "$full_ref" >/dev/null
+            cleanup_default="$(gh_api_read "repos/$GH_REPO" --jq '.default_branch')"
+            if [ "$head_ref" = "$cleanup_default" ]; then
+              echo "::error::Refusing to delete the current default branch '$head_ref'."
+              exit 1
+            fi
+
+            control_repo="$(mktemp -d "${RUNNER_TEMP:?}/genesis-merge-control.XXXXXX")"
+            trap 'rm -rf "$control_repo"' EXIT
+            git init --quiet "$control_repo"
+            gh auth setup-git --hostname github.com --force
+            remote_url="https://github.com/${GH_REPO}.git"
+
+            set +e
+            push_output="$(
+              git -C "$control_repo" push --porcelain \
+                "--force-with-lease=${full_ref}:${tested_sha}" \
+                "$remote_url" \
+                ":${full_ref}" 2>&1
+            )"
+            push_status=$?
+            set -e
+            printf '%s\n' "$push_output"
+            if (( push_status == 0 )); then
+              echo "Deleted merged head branch '$head_ref' at $tested_sha."
+              exit 0
+            fi
+
+            set +e
+            remote_record="$(
+              git -C "$control_repo" ls-remote \
+                --quiet --exit-code --refs \
+                "$remote_url" "$full_ref" 2>&1
+            )"
+            lookup_status=$?
+            set -e
+            case "$lookup_status" in
+              2)
+                echo "Head branch '$head_ref' is already absent; cleanup succeeded."
+                ;;
+              0)
+                read -r remote_sha _ <<<"$remote_record"
+                if [ "$remote_sha" != "$tested_sha" ]; then
+                  echo "::error::Head branch advanced to $remote_sha; refusing deletion."
+                else
+                  echo "::error::Head branch remains at $tested_sha, but deletion was rejected."
+                fi
+                exit 1
+                ;;
+              *)
+                printf '%s\n' "$remote_record" >&2
+                echo "::error::Unable to determine branch state after deletion failure."
+                exit 1
+                ;;
+            esac
             exit 0
           fi
 
+          if [[ ! "$stack_number" =~ ^[1-9][0-9]*$ ]] ||
+             [ "$stack_base_ref" != "$default_branch" ]; then
+            publish_status failure "Blocked: GitHub returned invalid stack identity."
+            echo "::error::Pull request #$pull_request_number has invalid stack identity."
+            exit 1
+          fi
+
+          stack="$(
+            gh_api_read \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/$GH_REPO/stacks/$stack_number"
+          )"
+          stack_size="$(jq '.pull_requests | length' <<<"$stack")"
+          if [ "$(jq -r '.open' <<<"$stack")" != 'true' ] ||
+             [ "$(jq -r '.base.ref // empty' <<<"$stack")" != "$default_branch" ] ||
+             [ "$stack_size" -lt 2 ] ||
+             [ "$stack_size" -gt 8 ]; then
+            publish_status failure "Blocked: stack #$stack_number is not an open default-branch stack."
+            echo "::error::Stack #$stack_number must be open, target '$default_branch', and contain 2 through 8 pull requests."
+            exit 1
+          fi
+
+          eligible_number=''
+          eligible_sha=''
+          while IFS= read -r entry; do
+            entry_number="$(jq -r '.number' <<<"$entry")"
+            entry_state="$(jq -r '.state' <<<"$entry")"
+            entry_draft="$(jq -r '.draft' <<<"$entry")"
+            entry_merged_at="$(jq -r '.merged_at // empty' <<<"$entry")"
+            entry_sha="$(jq -r '.head.sha // empty' <<<"$entry")"
+
+            if [ -n "$entry_merged_at" ]; then
+              continue
+            fi
+            tested_sha="$entry_sha"
+            if [ "$entry_state" != 'open' ] ||
+               [[ ! "$entry_number" =~ ^[1-9][0-9]*$ ]] ||
+               [[ ! "$entry_sha" =~ ^[0-9a-f]{40}$ ]]; then
+              publish_status failure "Blocked: stack #$stack_number contains an invalid unmerged entry."
+              echo "::error::Stack #$stack_number contains an invalid unmerged entry."
+              exit 1
+            fi
+            if [ "$entry_draft" = 'true' ]; then
+              publish_status pending "Waiting: stack pull request #$entry_number is draft."
+              echo "Stack pull request #$entry_number is draft; higher layers will not merge."
+              break
+            fi
+
+            entry_pr="$(
+              gh_api_read \
+                -H 'X-GitHub-Api-Version: 2026-03-10' \
+                "repos/$GH_REPO/pulls/$entry_number"
+            )"
+            if [ "$(jq -r '.stack.number // empty' <<<"$entry_pr")" != "$stack_number" ] ||
+               [ "$(jq -r '.stack.base.ref // empty' <<<"$entry_pr")" != "$default_branch" ] ||
+               [ "$(jq -r '.head.sha // empty' <<<"$entry_pr")" != "$entry_sha" ]; then
+              publish_status pending "Waiting: stack #$stack_number changed during evaluation."
+              echo "Stack #$stack_number changed during evaluation; leaving it open."
+              exit 0
+            fi
+
+            validate_pull_request "$entry_pr" "$entry_sha" "$entry_number"
+            case "$validation_state" in
+              success)
+                eligible_number="$entry_number"
+                eligible_sha="$entry_sha"
+                ;;
+              failure)
+                publish_status failure "Blocked: $validation_reason"
+                echo "::error::$validation_reason"
+                break
+                ;;
+              *)
+                publish_status pending "Waiting: $validation_reason"
+                echo "$validation_reason"
+                break
+                ;;
+            esac
+          done < <(jq -c '.pull_requests[]' <<<"$stack")
+
+          if [ -z "$eligible_number" ] || [ -z "$eligible_sha" ]; then
+            echo "Stack #$stack_number has no contiguous ready range with successful checks."
+            exit 0
+          fi
+
+          pull_request_number="$eligible_number"
+          tested_sha="$eligible_sha"
+          current_base_sha="$(gh_api_read "repos/$GH_REPO/commits/$default_branch" --jq '.sha')"
+          comparison_status="$(
+            gh_api_read \
+              "repos/$GH_REPO/compare/$current_base_sha...$tested_sha" \
+              --jq '.status'
+          )"
+          if [ "$comparison_status" != 'ahead' ] && [ "$comparison_status" != 'identical' ]; then
+            publish_status failure "Blocked: stack #$stack_number is not linear from current $default_branch."
+            echo "Stack #$stack_number does not contain current $default_branch commit $current_base_sha; rebase the stack."
+            exit 0
+          fi
+
+          merge_payload="$(
+            jq -n \
+              --arg sha "$tested_sha" '
+                {
+                  merge_method: "squash",
+                  merge_action: "direct_merge",
+                  sha: $sha
+                }
+              '
+          )"
+          set +e
           merge_response="$(
             gh api \
               --method PUT \
-              "repos/$GH_REPO/pulls/$pull_request_number/merge" \
-              -f merge_method=squash \
-              -f sha="$tested_sha"
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/$GH_REPO/pulls/$pull_request_number/merge-async" \
+              --input - <<<"$merge_payload" 2>&1
           )"
-          if [ "$(jq -r '.merged' <<<"$merge_response")" != "true" ]; then
-            message="$(jq -r '.message // "GitHub declined the merge."' <<<"$merge_response")"
-            echo "::error::Pull request $pull_request_number was not merged: $message"
+          merge_call_status=$?
+          set -e
+          if (( merge_call_status != 0 )); then
+            publish_status failure "Blocked: stack merge returned no authoritative response; inspect this run before retrying."
+            printf '%s\n' "$merge_response" >&2
             exit 1
           fi
+          merge_status="$(jq -r '.status // empty' <<<"$merge_response")"
 
-          merge_sha="$(jq -r '.sha' <<<"$merge_response")"
-          echo "Merged pull request $pull_request_number at $merge_sha."
-
-          cleanup_default="$(gh api "repos/$GH_REPO" --jq '.default_branch')"
-          if [ "$head_ref" = "$cleanup_default" ]; then
-            echo "::error::Refusing to delete the current default branch '$head_ref'."
-            exit 1
-          fi
-
-          control_repo="$(mktemp -d "${RUNNER_TEMP:?}/genesis-merge-control.XXXXXX")"
-          trap 'rm -rf "$control_repo"' EXIT
-          git init --quiet "$control_repo"
-          gh auth setup-git --hostname github.com --force
-          remote_url="https://github.com/${GH_REPO}.git"
-
-          set +e
-          push_output="$(
-            git -C "$control_repo" push --porcelain \
-              "--force-with-lease=${full_ref}:${tested_sha}" \
-              "$remote_url" \
-              ":${full_ref}" 2>&1
-          )"
-          push_status=$?
-          set -e
-          printf '%s\n' "$push_output"
-
-          if (( push_status == 0 )); then
-            echo "Deleted merged head branch '$head_ref' at $tested_sha."
-            exit 0
-          fi
-
-          set +e
-          remote_record="$(
-            git -C "$control_repo" ls-remote \
-              --quiet --exit-code --refs \
-              "$remote_url" "$full_ref" 2>&1
-          )"
-          lookup_status=$?
-          set -e
-
-          case "$lookup_status" in
-            2)
-              echo "Head branch '$head_ref' is already absent; cleanup succeeded."
-              ;;
-            0)
-              read -r remote_sha _ <<<"$remote_record"
-              if [ "$remote_sha" != "$tested_sha" ]; then
-                echo "::error::Head branch advanced to $remote_sha; refusing deletion."
-              else
-                echo "::error::Head branch remains at $tested_sha, but deletion was rejected."
+          if [ "$merge_status" = 'pending' ]; then
+            merge_uuid="$(jq -r '.details.uuid // empty' <<<"$merge_response")"
+            if [[ ! "$merge_uuid" =~ ^[0-9a-fA-F-]{36}$ ]]; then
+              publish_status failure "Blocked: GitHub returned no asynchronous merge identifier."
+              echo "::error::GitHub returned no asynchronous merge identifier."
+              exit 1
+            fi
+            for attempt in $(seq 1 120); do
+              sleep 2
+              set +e
+              merge_response="$(
+                gh_api_read \
+                  -H 'X-GitHub-Api-Version: 2026-03-10' \
+                  "repos/$GH_REPO/pulls/$pull_request_number/merge-async/$merge_uuid"
+              )"
+              merge_poll_status=$?
+              set -e
+              if (( merge_poll_status != 0 )); then
+                publish_status pending "Waiting: asynchronous merge result is temporarily unavailable; do not resubmit blindly."
+                echo "::error::Unable to read asynchronous merge result after bounded retries."
+                exit 1
               fi
+              merge_status="$(jq -r '.status // empty' <<<"$merge_response")"
+              if [ "$merge_status" != 'pending' ]; then
+                break
+              fi
+            done
+          fi
+
+          case "$merge_status" in
+            merged)
+              merge_sha="$(jq -r '.details.sha // empty' <<<"$merge_response")"
+              publish_status success "Merged stack #$stack_number through #$pull_request_number as ${merge_sha:0:7}."
+              echo "Merged stack #$stack_number through pull request #$pull_request_number at $merge_sha."
+              ;;
+            enqueued)
+              publish_status success "Enqueued stack #$stack_number through #$pull_request_number."
+              echo "Enqueued stack #$stack_number through pull request #$pull_request_number."
+              ;;
+            failed)
+              message="$(jq -r '.details.message // "GitHub declined the stack merge."' <<<"$merge_response")"
+              publish_status failure "Blocked: $message"
+              echo "::error::Stack #$stack_number was not merged: $message"
+              exit 1
+              ;;
+            pending)
+              publish_status failure "Blocked: asynchronous stack merge timed out."
+              echo "::error::Asynchronous stack merge did not finish within four minutes."
               exit 1
               ;;
             *)
-              printf '%s\n' "$remote_record" >&2
-              echo "::error::Unable to determine branch state after deletion failure."
+              publish_status failure "Blocked: GitHub returned unknown asynchronous merge state."
+              echo "::error::Unknown asynchronous merge state '$merge_status'."
               exit 1
               ;;
           esac

--- a/.github/genesis-delivery.json
+++ b/.github/genesis-delivery.json
@@ -6,6 +6,7 @@
   "ciWorkflow": "CI",
   "requiredChecks": [
     "CI",
+    "PR base",
     "PR title",
     "Review policy"
   ],
@@ -16,6 +17,39 @@
   },
   "runnerProfiles": [],
   "componentWorkflows": [
+    {
+      "source": "github-stacked-pr-delivery",
+      "path": ".github/workflows/pr-base.yml",
+      "roles": [
+        "merge-gate"
+      ],
+      "draftBehavior": "full",
+      "requiredChecks": [
+        "PR base"
+      ]
+    },
+    {
+      "source": "github-stacked-pr-delivery",
+      "path": ".github/workflows/pr-title.yml",
+      "roles": [
+        "merge-gate"
+      ],
+      "draftBehavior": "full",
+      "requiredChecks": [
+        "PR title"
+      ]
+    },
+    {
+      "source": "github-stacked-pr-delivery",
+      "path": ".github/workflows/pr-review-policy.yml",
+      "roles": [
+        "merge-gate"
+      ],
+      "draftBehavior": "full",
+      "requiredChecks": [
+        "Review policy"
+      ]
+    },
     {
       "source": "repository",
       "path": ".github/workflows/release.yml",

--- a/.github/genesis-delivery.schema.json
+++ b/.github/genesis-delivery.schema.json
@@ -122,7 +122,14 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-              "enum": ["merge-gate", "draft-optional", "post-merge", "release-deploy"]
+              "enum": [
+                "merge-gate",
+                "draft-optional",
+                "post-merge",
+                "release-deploy",
+                "issue-automation",
+                "repository-automation"
+              ]
             }
           },
           "draftBehavior": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: CI
 on:
   pull_request:
     branches: [master]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, stacked]
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [master]
   workflow_dispatch:
@@ -98,7 +100,7 @@ jobs:
   ci:
     name: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft && 'Draft CI' || 'CI' }}
     needs: [validation-plan, build-and-test]
-    if: always()
+    if: '!cancelled()'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pr-base.yml
+++ b/.github/workflows/pr-base.yml
@@ -1,0 +1,112 @@
+name: PR base
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review, stacked]
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  base:
+    name: PR base
+    runs-on: ${{ github.event_name == 'merge_group' && (vars.REPOSITORY_AUTOMATION_CONTROL_RUNNER || (github.event.repository.private && 'repository-automation-capability-unavailable' || 'ubuntu-24.04')) || github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24.04' || github.event.repository.private && (vars.REPOSITORY_AUTOMATION_CONTROL_RUNNER || 'repository-automation-capability-unavailable') || (vars.REPOSITORY_AUTOMATION_CONTROL_RUNNER || 'ubuntu-24.04') }}
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      EVENT_NAME: ${{ github.event_name }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
+    steps:
+      - name: Verify the pull request base or native stack
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = 'merge_group' ]; then
+            merge_group_base="${MERGE_GROUP_BASE_REF#refs/heads/}"
+            if [ "$merge_group_base" != "$DEFAULT_BRANCH" ]; then
+              echo "::error::Merge group targets '$merge_group_base' instead of '$DEFAULT_BRANCH'."
+              exit 1
+            fi
+            echo "Merge group targets the protected stack trunk '$DEFAULT_BRANCH'."
+            exit 0
+          fi
+
+          pull_request=''
+          for attempt in 1 2 3; do
+            if pull_request="$(
+              gh api \
+                -H 'X-GitHub-Api-Version: 2026-03-10' \
+                "repos/$GH_REPO/pulls/$PR_NUMBER"
+            )"; then
+              break
+            fi
+            pull_request=''
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$(( attempt * 5 ))"
+            fi
+          done
+
+          if [ -z "$pull_request" ]; then
+            echo "::error::Could not read pull request #$PR_NUMBER after 3 attempts; its delivery base was not verified."
+            exit 1
+          fi
+
+          base_ref="$(jq -r '.base.ref // empty' <<<"$pull_request")"
+          default_branch="$(jq -r '.base.repo.default_branch // empty' <<<"$pull_request")"
+          head_repo="$(jq -r '.head.repo.full_name // empty' <<<"$pull_request")"
+          base_repo="$(jq -r '.base.repo.full_name // empty' <<<"$pull_request")"
+          stack_number="$(jq -r '.stack.number // empty' <<<"$pull_request")"
+          stack_size="$(jq -r '.stack.size // empty' <<<"$pull_request")"
+          stack_position="$(jq -r '.stack.position // empty' <<<"$pull_request")"
+          stack_base_ref="$(jq -r '.stack.base.ref // empty' <<<"$pull_request")"
+          stack_base_sha="$(jq -r '.stack.base.sha // empty' <<<"$pull_request")"
+
+          if [ -z "$base_ref" ] ||
+             [ -z "$default_branch" ] ||
+             [ -z "$head_repo" ] ||
+             [ -z "$base_repo" ]; then
+            echo "::error::Pull request #$PR_NUMBER reported incomplete branch identity."
+            exit 1
+          fi
+
+          if [ -z "$stack_number" ]; then
+            if [ "$base_ref" != "$default_branch" ]; then
+              echo "::error::Pull request #$PR_NUMBER targets '$base_ref' instead of '$default_branch' and GitHub reports no native stack membership."
+              exit 1
+            fi
+            echo "Pull request targets the default branch '$default_branch'."
+            exit 0
+          fi
+
+          if [ "$head_repo" != "$GH_REPO" ] ||
+             [ "$base_repo" != "$GH_REPO" ]; then
+            echo "::error::Stacked pull requests must use branches from '$GH_REPO'; forks are not supported by GitHub stacks."
+            exit 1
+          fi
+          if [[ ! "$stack_number" =~ ^[1-9][0-9]*$ ]] ||
+             [[ ! "$stack_position" =~ ^[1-9][0-9]*$ ]] ||
+             [[ ! "$stack_size" =~ ^[1-9][0-9]*$ ]] ||
+             [ "$stack_size" -lt 2 ] ||
+             [ "$stack_size" -gt 8 ] ||
+             [ "$stack_position" -gt "$stack_size" ] ||
+             [[ ! "$stack_base_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::GitHub returned malformed stack metadata for pull request #$PR_NUMBER."
+            exit 1
+          fi
+          if [ "$stack_base_ref" != "$default_branch" ]; then
+            echo "::error::Stack #$stack_number targets '$stack_base_ref'; this delivery contract supports only the default branch '$default_branch' as the stack trunk."
+            exit 1
+          fi
+          if [ "$base_ref" != "$default_branch" ] && [ "$stack_position" -eq 1 ]; then
+            echo "::error::GitHub stack #$stack_number reports an invalid bottom pull request base."
+            exit 1
+          fi
+
+          echo "Pull request #$PR_NUMBER is layer $stack_position/$stack_size of GitHub stack #$stack_number targeting '$default_branch'."

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -1,37 +1,47 @@
 name: Review policy evaluator
-run-name: "Review policy for #${{ github.event.pull_request.number }} at ${{ github.event.pull_request.head.sha }}"
+run-name: ${{ github.event_name == 'merge_group' && format('Review policy for merge group {0}', github.event.merge_group.head_sha) || format('Review policy for #{0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
 on:
+  pull_request:
+    branches: [master]
+    types: [stacked]
   pull_request_target:
     branches: [master]
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   pull_request_review:
     types: [submitted, dismissed]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
-  checks: write
   contents: read
   pull-requests: read
 
 concurrency:
-  group: review-policy-${{ github.event.pull_request.number }}
+  group: review-policy-${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   evaluate:
-    name: Evaluate review policy
-    runs-on: ubuntu-latest
+    name: Review policy
+    runs-on: ${{ github.event_name == 'merge_group' && (vars.REPOSITORY_AUTOMATION_CONTROL_RUNNER || (github.event.repository.private && 'repository-automation-capability-unavailable' || 'ubuntu-24.04')) || github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24.04' || github.event.repository.private && (vars.REPOSITORY_AUTOMATION_CONTROL_RUNNER || 'repository-automation-capability-unavailable') || (vars.REPOSITORY_AUTOMATION_CONTROL_RUNNER || 'ubuntu-24.04') }}
     timeout-minutes: 5
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
+      EVENT_NAME: ${{ github.event_name }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       REVIEW_POLICY: ${{ vars.GENESIS_REVIEW_POLICY || 'none' }}
     steps:
-      - name: Publish review policy check
+      - name: Evaluate review policy
         shell: bash
         run: |
           set -euo pipefail
+
+          if [ "$EVENT_NAME" = 'merge_group' ]; then
+            echo "Every queued stack layer satisfied the review policy before enqueue."
+            exit 0
+          fi
 
           pull_request="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER")"
           head_sha="$(jq -r '.head.sha' <<<"$pull_request")"
@@ -39,7 +49,6 @@ jobs:
           author_type="$(jq -r '.user.type' <<<"$pull_request")"
           is_draft="$(jq -r '.draft' <<<"$pull_request")"
           conclusion=success
-          title='Review policy satisfied'
           summary='No author-specific review is required.'
 
           case "$REVIEW_POLICY" in
@@ -83,7 +92,6 @@ jobs:
                   )"
                   if [ "$approval_count" -lt 1 ]; then
                     conclusion=failure
-                    title='Human approval required'
                     summary='Copilot-authored ready pull requests require an OWNER, MEMBER, or COLLABORATOR approval on the current head SHA.'
                   else
                     summary='A trusted human approved the current Copilot-authored head SHA.'
@@ -93,33 +101,11 @@ jobs:
               ;;
             *)
               conclusion=failure
-              title='Unsupported review policy'
               summary="GENESIS_REVIEW_POLICY '$REVIEW_POLICY' is not supported."
               ;;
           esac
 
-          jq -n \
-            --arg name 'Review policy' \
-            --arg head_sha "$head_sha" \
-            --arg conclusion "$conclusion" \
-            --arg title "$title" \
-            --arg summary "$summary" '
-              {
-                name: $name,
-                head_sha: $head_sha,
-                status: "completed",
-                conclusion: $conclusion,
-                output: {
-                  title: $title,
-                  summary: $summary
-                }
-              }
-            ' |
-            gh api \
-              --method POST \
-              "repos/$GH_REPO/check-runs" \
-              --input - >/dev/null
-
+          echo "$summary"
           if [ "$conclusion" != 'success' ]; then
             echo "::error::$summary"
             exit 1

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,35 +3,72 @@ name: PR title
 on:
   pull_request:
     branches: [master]
-    types: [opened, edited, synchronize, reopened, ready_for_review]
+    types: [opened, edited, synchronize, reopened, ready_for_review, stacked]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   title:
     name: PR title
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'merge_group' && (vars.REPOSITORY_AUTOMATION_CONTROL_RUNNER || (github.event.repository.private && 'repository-automation-capability-unavailable' || 'ubuntu-24.04')) || github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-24.04' || github.event.repository.private && (vars.REPOSITORY_AUTOMATION_CONTROL_RUNNER || 'repository-automation-capability-unavailable') || (vars.REPOSITORY_AUTOMATION_CONTROL_RUNNER || 'ubuntu-24.04') }}
     timeout-minutes: 5
     env:
-      PR_TITLE: ${{ github.event.pull_request.title }}
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      EVENT_NAME: ${{ github.event_name }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
       TITLE_MAX_LENGTH: '72'
       TITLE_PATTERN: '^(feat|fix|docs|refactor|test|style|build|ci|chore|perf|revert)(\([a-z0-9][a-z0-9._/-]*\))?!?: .+$'
     steps:
       - name: Validate conventional title
         shell: bash
         run: |
-          if [[ "$PR_TITLE" == *$'\n'* || "$PR_TITLE" == *$'\r'* ]]; then
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = 'merge_group' ]; then
+            echo "Every queued stack layer satisfied the PR title check before enqueue."
+            exit 0
+          fi
+
+          pull_request=''
+          for attempt in 1 2 3; do
+            if pull_request="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER")"; then
+              break
+            fi
+            pull_request=''
+            if [ "$attempt" -lt 3 ]; then
+              sleep "$(( attempt * 5 ))"
+            fi
+          done
+
+          if [ -z "$pull_request" ]; then
+            echo "::error::Could not read pull request #$PR_NUMBER after 3 attempts; the title was not validated."
+            exit 1
+          fi
+
+          pr_title="$(jq -r '.title // empty' <<<"$pull_request")"
+          if [ -z "$pr_title" ]; then
+            echo "::error::Pull request #$PR_NUMBER reported no title; the title was not validated."
+            exit 1
+          fi
+
+          echo "Validating title: $pr_title"
+
+          if [[ "$pr_title" == *$'\n'* || "$pr_title" == *$'\r'* ]]; then
             echo "::error::Pull request title must be a single line."
             exit 1
           fi
 
-          if (( ${#PR_TITLE} > TITLE_MAX_LENGTH )); then
-            echo "::error::Pull request title is ${#PR_TITLE} characters; maximum is $TITLE_MAX_LENGTH."
+          if (( ${#pr_title} > TITLE_MAX_LENGTH )); then
+            echo "::error::Pull request title is ${#pr_title} characters; maximum is $TITLE_MAX_LENGTH."
             exit 1
           fi
 
-          if [[ ! "$PR_TITLE" =~ $TITLE_PATTERN ]]; then
+          if [[ ! "$pr_title" =~ $TITLE_PATTERN ]]; then
             echo "::error::Use a conventional title such as 'feat(scope): description'."
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,15 @@ opted into via `global.json`. A few gotchas worth knowing:
 Report exact warning/error and pass/fail/skip counts rather than saying only
 that tests passed. Do not say "all tests pass" — show the numbers.
 
-## Pull Request Delivery
+## Delivery
 
+The exact, machine-readable delivery contract lives in
+[`.github/genesis-delivery.json`](.github/genesis-delivery.json); it is the
+source of truth for required checks, draft behavior, and workflow roles. The
+notes below summarize it and never override it.
+
+- `master` is this repository's default branch. Every pull request targets the
+  default branch unless it is a layer in a stacked pull request.
 - Local commits are unrestricted checkpoints — commit as often as is useful and
   do not stop to assemble a self-assessment for one. The assessment gate lives
   at ready delivery, not at `git commit`. Local commits belong on feature
@@ -72,6 +79,13 @@ that tests passed. Do not say "all tests pass" — show the numbers.
   active, `.githooks/pre-push` blocks updates or deletion of `master`; deliver
   changes through pull requests. `.githooks/commit-msg` enforces the
   conventional-commit subject format on every commit.
+- Target `master` unless you are deliberately building a stacked pull request.
+  This repository enables same-repository stacked pull requests through the
+  `github-stacked-pr-delivery` component; see
+  [docs/stacked-pull-requests.md](docs/stacked-pull-requests.md) for the rules.
+  A stack is linear, stays in this repository, is at most eight layers, and its
+  bottom layer targets `master`. Fork pull requests remain ordinary pull
+  requests targeting `master`.
 - Run targeted checks while iterating and the full repository validation before
   delivery. This public repository uses GitHub-hosted runners; no self-hosted
   runner route is declared in `.github/genesis-delivery.json`.
@@ -81,6 +95,13 @@ that tests passed. Do not say "all tests pass" — show the numbers.
 - Draft pull requests publish `Draft CI` without the full build/test/package
   job. Moving a pull request to ready starts fresh full validation and publishes
   the stable required `CI` check.
+- The required merge gates are `CI`, `PR base`, `PR title`, and `Review policy`.
+  `PR base` is deliberately the only pull-request workflow with no branch
+  filter, so a pull request that targets neither `master` nor a valid stack
+  layer fails visibly instead of silently receiving no checks at all.
+- `enforce_admins` is enabled on `master`, matching the Genesis contract. There
+  is no administrator bypass: a blocked pull request is fixed by making its
+  required checks pass, not by overriding protection.
 - When `GENESIS_REVIEW_POLICY=copilot-one-approval`, a ready Copilot-authored
   pull request requires one OWNER, MEMBER, or COLLABORATOR approval on its
   current head SHA. A later Copilot push invalidates the prior approval.

--- a/docs/stacked-pull-requests.md
+++ b/docs/stacked-pull-requests.md
@@ -1,0 +1,65 @@
+# Stacked pull requests
+
+This repository supports GitHub-native, same-repository stacked pull requests. A stack
+is a linear chain of pull requests whose bottom layer targets the default branch and
+whose later layers target the branch immediately below them.
+
+The generated delivery contract records the component's classified `PR base` workflow.
+`Configure-GitHubDelivery.ps1` keeps the repository's existing delivery-mode decision:
+
+- **Native** uses GitHub's stack-level branch protections, required checks, reviews,
+  asynchronous merge API, and merge queue when those controls are available. The
+  component adds `merge_group` execution for CI and republishes the PR title, review
+  policy, and base contexts required by the queue. Other generated merge-gate
+  components also report their required contexts for merge groups.
+- **WorkflowRun** uses the trusted private merge workflow to revalidate every ready
+  layer against the generated delivery contract before submitting the same
+  asynchronous exact-head stack merge.
+
+## Create and maintain a stack
+
+Install GitHub's public-preview CLI extension:
+
+```shell
+gh extension install github/gh-stack
+```
+
+Create, submit, and rebase stacks with:
+
+```shell
+gh stack init
+gh stack submit
+gh stack rebase
+gh stack push
+```
+
+Stacks must stay in one repository, remain fully linear, and contain no more than eight
+pull requests. Fork pull requests remain ordinary pull requests targeting the default
+branch.
+
+## Merge behavior
+
+GitHub evaluates every layer against the stack trunk, so existing CI workflows scoped
+to the default branch run for each layer. Squash merging produces one commit per pull
+request in bottom-to-top order.
+
+Native GitHub auto-merge is not available for stacked pull requests. Merge a ready
+stack from the GitHub merge box, `gh stack`, or a configured merge queue. In
+WorkflowRun mode, the trusted controller supplies equivalent automatic progression
+after every generated required check succeeds on the exact layer heads.
+
+## Configure delivery
+
+Plan the live repository configuration before applying it:
+
+```powershell
+./scripts/delivery/Configure-GitHubDelivery.ps1 -DeliveryMode Auto
+```
+
+Public repositories normally select Native mode. Private repositories whose plan
+cannot enforce branch protection select WorkflowRun mode and require the explicit
+`-AllowUnprotectedPrivate` acknowledgement when applying.
+
+The GitHub stack APIs are in public preview and require API version `2026-03-10`.
+Unsupported or malformed stack metadata fails closed rather than being treated as an
+ordinary non-default-base pull request.

--- a/scripts/delivery/Configure-GitHubDelivery.ps1
+++ b/scripts/delivery/Configure-GitHubDelivery.ps1
@@ -37,8 +37,17 @@
     None, or CopilotOneApproval. CopilotOneApproval requires one trusted human
     approval on the current SHA before a ready Copilot-authored PR can merge.
 
+.PARAMETER ControlRunner
+    Runner label or hosted image used by deterministic repository controls. Public
+    repositories default to ubuntu-24.04. Private repositories require an explicit
+    value; ubuntu-24.04 is the manual hosted-recovery choice.
+
 .PARAMETER SnapshotPath
     Optional offline repository snapshot used by Genesis contract tests.
+
+.PARAMETER AuditProtectionDrift
+    Return the deterministic delivery-protection drift assessment without planning
+    or applying repository mutations.
 
 .PARAMETER GhCommand
     gh executable path. Defaults to `gh`.
@@ -60,7 +69,9 @@ param(
     [switch]$AllowUnprotectedPrivate,
     [ValidateSet('None', 'CopilotOneApproval')]
     [string]$ReviewPolicy = 'None',
+    [string]$ControlRunner,
     [string]$SnapshotPath,
+    [switch]$AuditProtectionDrift,
     [string]$GhCommand = 'gh'
 )
 
@@ -75,6 +86,13 @@ if (-not (Test-Path $contractPath)) {
 }
 
 $contract = Get-Content $contractPath -Raw | ConvertFrom-Json
+$stackedPullRequests = @(
+    $contract.componentWorkflows |
+        Where-Object {
+            [string]$_.source -ceq 'github-stacked-pr-delivery' -and
+            [string]$_.path -ceq '.github/workflows/pr-base.yml'
+        }
+).Count -eq 1
 $requiredChecks = @($contract.requiredChecks | ForEach-Object { [string]$_ })
 $draftMode =
     if (@($contract.runnerProfiles).Count -gt 0) {
@@ -82,6 +100,194 @@ $draftMode =
     } else {
         [string]$contract.draftValidation.hostedDefault
     }
+
+function Test-ObjectProperties {
+    param(
+        [AllowNull()]
+        [object]$Value,
+
+        [Parameter(Mandatory)]
+        [string[]]$Names
+    )
+
+    if ($null -eq $Value) {
+        return $false
+    }
+    $propertyNames = @($Value.PSObject.Properties.Name)
+    return @($Names | Where-Object { $_ -notin $propertyNames }).Count -eq 0
+}
+
+function Test-EmptyActorCollections {
+    param([AllowNull()][object]$Value)
+
+    if ($null -eq $Value) {
+        return $true
+    }
+    return (
+        @($Value.users | Where-Object { $null -ne $_ }).Count -eq 0 -and
+        @($Value.teams | Where-Object { $null -ne $_ }).Count -eq 0 -and
+        @($Value.apps | Where-Object { $null -ne $_ }).Count -eq 0
+    )
+}
+
+function Test-LegacyZeroReviewProtection {
+    param([AllowNull()][object]$ReviewRequirement)
+
+    if (-not (Test-ObjectProperties `
+        -Value $ReviewRequirement `
+        -Names @(
+            'dismiss_stale_reviews',
+            'require_code_owner_reviews',
+            'required_approving_review_count',
+            'require_last_push_approval'
+        ))) {
+        return $false
+    }
+    return (
+        [int]$ReviewRequirement.required_approving_review_count -eq 0 -and
+        -not [bool]$ReviewRequirement.dismiss_stale_reviews -and
+        -not [bool]$ReviewRequirement.require_code_owner_reviews -and
+        -not [bool]$ReviewRequirement.require_last_push_approval -and
+        (Test-EmptyActorCollections `
+            -Value $ReviewRequirement.bypass_pull_request_allowances) -and
+        (Test-EmptyActorCollections `
+            -Value $ReviewRequirement.dismissal_restrictions)
+    )
+}
+
+function Test-CheckCollectionsEqual {
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Left,
+
+        [Parameter(Mandatory)]
+        [object[]]$Right
+    )
+
+    $leftKeys = @(
+        $Left |
+            ForEach-Object {
+                "$([string]$_.context):$([int]$_.app_id)"
+            } |
+            Sort-Object -Unique
+    )
+    $rightKeys = @(
+        $Right |
+            ForEach-Object {
+                "$([string]$_.context):$([int]$_.app_id)"
+            } |
+            Sort-Object -Unique
+    )
+    return ($leftKeys -join ',') -ceq ($rightKeys -join ',')
+}
+
+function Test-ClassicProtectionSafety {
+    param(
+        [AllowNull()]
+        [object]$Protection,
+
+        [Parameter(Mandatory)]
+        [string[]]$RequiredChecks
+    )
+
+    if (-not (Test-ObjectProperties `
+        -Value $Protection `
+        -Names @(
+            'required_status_checks',
+            'enforce_admins',
+            'required_conversation_resolution',
+            'allow_force_pushes',
+            'allow_deletions',
+            'required_linear_history',
+            'block_creations',
+            'lock_branch',
+            'allow_fork_syncing',
+            'required_signatures'
+        ))) {
+        return $false
+    }
+    $existingChecks = @($Protection.required_status_checks.checks)
+    $missingChecks = @(
+        $RequiredChecks |
+            Where-Object {
+                $requiredCheck = $_
+                -not ($existingChecks | Where-Object {
+                    [string]$_.context -ceq $requiredCheck -and
+                    [int]$_.app_id -eq 15368
+                })
+            }
+    )
+    return (
+        $missingChecks.Count -eq 0 -and
+        [bool]$Protection.required_status_checks.strict -and
+        [bool]$Protection.enforce_admins.enabled -and
+        -not [bool]$Protection.allow_force_pushes.enabled -and
+        -not [bool]$Protection.allow_deletions.enabled -and
+        -not [bool]$Protection.required_linear_history.enabled -and
+        -not [bool]$Protection.block_creations.enabled -and
+        -not [bool]$Protection.lock_branch.enabled -and
+        -not [bool]$Protection.allow_fork_syncing.enabled -and
+        -not [bool]$Protection.required_signatures.enabled -and
+        $null -eq $Protection.restrictions
+    )
+}
+
+function Test-DesiredClassicProtection {
+    param(
+        [AllowNull()]
+        [object]$Protection,
+
+        [Parameter(Mandatory)]
+        [object[]]$ExpectedChecks
+    )
+
+    return (
+        (Test-ClassicProtectionSafety `
+            -Protection $Protection `
+            -RequiredChecks @($ExpectedChecks | ForEach-Object { [string]$_.context })) -and
+        (Test-CheckCollectionsEqual `
+            -Left @($Protection.required_status_checks.checks) `
+            -Right $ExpectedChecks) -and
+        $null -eq $Protection.required_pull_request_reviews -and
+        -not [bool]$Protection.required_conversation_resolution.enabled -and
+        -not [bool]$Protection.required_linear_history.enabled -and
+        -not [bool]$Protection.block_creations.enabled -and
+        -not [bool]$Protection.lock_branch.enabled -and
+        -not [bool]$Protection.allow_fork_syncing.enabled
+    )
+}
+
+function New-ClassicProtectionBody {
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Checks
+    )
+
+    return [ordered]@{
+        required_status_checks = [ordered]@{
+            strict = $true
+            checks = @(
+                $Checks |
+                    ForEach-Object {
+                        [ordered]@{
+                            context = [string]$_.context
+                            app_id = [int]$_.app_id
+                        }
+                    }
+            )
+        }
+        enforce_admins = $true
+        required_pull_request_reviews = $null
+        restrictions = $null
+        required_linear_history = $false
+        allow_force_pushes = $false
+        allow_deletions = $false
+        block_creations = $false
+        required_conversation_resolution = $false
+        lock_branch = $false
+        allow_fork_syncing = $false
+    }
+}
 
 function Invoke-GhJson {
     param(
@@ -97,6 +303,152 @@ function Invoke-GhJson {
         return $null
     }
     return (($output -join "`n") | ConvertFrom-Json)
+}
+
+function Test-LegacyMergeAutomation {
+    param([string]$WorkflowText)
+
+    foreach ($pattern in @(
+        '(?i)\bgh\s+pr\s+merge\b',
+        '(?i)\b(?:github|octokit)\.rest\.pulls\.merge\b',
+        '(?i)\benablePullRequestAutoMerge\b',
+        '(?i)\bmergePullRequest\b',
+        '(?i)repos/.+/pulls/.+/merge',
+        '(?i)\benable-pull-request-automerge\b',
+        '(?i)\b(?:automerge|auto-merge)[-/]action\b',
+        '(?im)^\s*-\s*uses:\s*[^#\r\n]*(?:auto.?merge|automerge|merge-me|dependabot-auto-merge)[^#\r\n]*@'
+    )) {
+        if ($WorkflowText -match $pattern) {
+            return $true
+        }
+    }
+    $hasPullRequestWrite = (
+        $WorkflowText -match '(?i)\bpull-requests\s*:\s*write\b' -or
+        $WorkflowText -match '(?i)\bpermissions\s*:\s*write-all\b'
+    )
+    return (
+        $hasPullRequestWrite -and
+        $WorkflowText -match '(?im)^\s*-\s*uses:\s+\./')
+}
+
+function Test-StandardPrivateAutoMerge {
+    param([string]$WorkflowText)
+
+    return (
+        $WorkflowText -match "GENESIS_DELIVERY_MODEL == 'workflow-run'" -and
+        $WorkflowText -notmatch 'actions/checkout' -and
+        $WorkflowText -match 'head\.repo\.full_name == \$repo' -and
+        $WorkflowText -match '-f sha="\$tested_sha"' -and
+        $WorkflowText -match '\.app\.id == \$app_id' -and
+        $WorkflowText -match '--force-with-lease=\$\{full_ref\}:\$\{tested_sha\}'
+    )
+}
+
+function Get-LegacyMergeWorkflowPaths {
+    $workflowsRoot = Join-Path $ProjectRoot '.github' 'workflows'
+    if (-not (Test-Path -LiteralPath $workflowsRoot -PathType Container)) {
+        return @()
+    }
+
+    return @(
+        Get-ChildItem -LiteralPath $workflowsRoot -File |
+            Where-Object { $_.Extension -in @('.yml', '.yaml') } |
+            Where-Object {
+                $text = Get-Content -LiteralPath $_.FullName -Raw
+                if ($_.Name -ceq 'private-auto-merge.yml') {
+                    -not (Test-StandardPrivateAutoMerge -WorkflowText $text)
+                } else {
+                    Test-LegacyMergeAutomation -WorkflowText $text
+                }
+            } |
+            ForEach-Object {
+                $_.FullName.Substring($ProjectRoot.Length + 1) -replace '\\', '/'
+            } |
+            Sort-Object -Unique)
+}
+
+function Get-NativeMissingChecksNextAction {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$MissingChecks,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [string[]]$BootstrapBlockers
+    )
+
+    if ($MissingChecks.Count -eq 1 -and $MissingChecks[0] -ceq 'Review policy') {
+        if ($BootstrapBlockers.Count -gt 0) {
+            return "Review policy became available only after the migration reached the default branch. Empty-commit bootstrap PR mode is unsafe here: $($BootstrapBlockers -join '; '). Request a real harmless change PR that satisfies CI, PR title, Review policy, and every repository-specific required check, rerun activation with that PR's exact head SHA via -CheckSha, and do not weaken workflows or add permanent marker files."
+        }
+
+        return 'Review policy became available only after the migration reached the default branch. Use a genuine ready PR when available; otherwise, only with explicit user approval, create a bootstrap branch with `git commit --allow-empty -m "chore: bootstrap Genesis delivery activation"` and open a ready PR titled `chore: bootstrap Genesis delivery activation`. Verify CI, PR title, Review policy, and every repository-specific required check on that PR''s exact head SHA, rerun activation with -CheckSha, require a separate explicit approval before -Apply, then arm squash auto-merge only after activation so the bootstrap PR itself proves merge plus head-branch deletion.'
+    }
+
+    return "Run the required workflows, then rerun with -CheckSha <sha>. Missing: $($MissingChecks -join ', ')."
+}
+
+function Get-EmptyBootstrapPrBlockers {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ProjectRoot
+    )
+
+    $workflowsRoot = Join-Path $ProjectRoot '.github' 'workflows'
+    if (-not (Test-Path -LiteralPath $workflowsRoot -PathType Container)) {
+        return @()
+    }
+
+    $blockers = [System.Collections.Generic.List[string]]::new()
+    $prOpenTypes = @('opened', 'synchronize', 'reopened', 'ready_for_review')
+    foreach ($workflowPath in @(
+        Get-ChildItem -LiteralPath $workflowsRoot -File |
+            Where-Object { $_.Extension -in @('.yml', '.yaml') } |
+            ForEach-Object { $_.FullName } |
+            Sort-Object
+    )) {
+        $text = Get-Content -LiteralPath $workflowPath -Raw
+        $relativePath = $workflowPath.Substring($ProjectRoot.Length + 1) -replace '\\', '/'
+        $hasPrTrigger = (
+            $text -match '(?im)^\s*pull_request(?:_target)?\s*:' -or
+            $text -match '(?im)^\s*on\s*:\s*\[[^\]]*\bpull_request(?:_target)?\b'
+        )
+        if (-not $hasPrTrigger) {
+            continue
+        }
+
+        if ($text -match '(?im)^\s*paths(?:-ignore)?\s*:') {
+            $blockers.Add("$relativePath uses paths or paths-ignore filters for pull-request events") | Out-Null
+            continue
+        }
+
+        $typeFilter = [regex]::Match(
+            $text,
+            '(?ims)^\s*pull_request(?:_target)?\s*:\s*(?<body>(?:\s{2,}.*\r?\n)+)'
+        )
+        if (-not $typeFilter.Success) {
+            continue
+        }
+
+        $body = $typeFilter.Groups['body'].Value
+        if ($body -notmatch '(?im)^\s*types\s*:') {
+            continue
+        }
+
+        $allowsPrOpenEvent = $false
+        foreach ($event in $prOpenTypes) {
+            if ($body -match "(?im)(?:^\s*-\s*$event\s*$|^\s*types\s*:\s*\[[^\]]*\b$event\b)") {
+                $allowsPrOpenEvent = $true
+                break
+            }
+        }
+
+        if (-not $allowsPrOpenEvent) {
+            $blockers.Add("$relativePath restricts pull_request types away from opened/synchronize/reopened/ready_for_review") | Out-Null
+        }
+    }
+
+    return @($blockers)
 }
 
 function Get-LiveSnapshot {
@@ -121,6 +473,37 @@ function Get-LiveSnapshot {
         'api', '-H', 'X-GitHub-Api-Version: 2026-03-10',
         "repos/$resolvedRepository")
     $defaultBranch = [string]$repositoryState.default_branch
+    $remoteLegacyMergeWorkflows = [System.Collections.Generic.List[string]]::new()
+    $remoteWorkflowEntries = Invoke-GhJson -Arguments @(
+        'api',
+        '-H', 'X-GitHub-Api-Version: 2026-03-10',
+        "repos/$resolvedRepository/contents/.github/workflows?ref=$defaultBranch")
+    foreach ($entry in @($remoteWorkflowEntries)) {
+        $path = [string]$entry.path
+        if (
+            [string]$entry.type -cne 'file' -or
+            [IO.Path]::GetExtension($path) -notin @('.yml', '.yaml')
+        ) {
+            continue
+        }
+        $workflowOutput = & $GhCommand api `
+            -H 'Accept: application/vnd.github.raw+json' `
+            -H 'X-GitHub-Api-Version: 2026-03-10' `
+            "repos/$resolvedRepository/contents/${path}?ref=$defaultBranch"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Unable to inspect remote workflow '$path'."
+        }
+        $workflowText = $workflowOutput -join "`n"
+        $isLegacy =
+            if ([IO.Path]::GetFileName($path) -ceq 'private-auto-merge.yml') {
+                -not (Test-StandardPrivateAutoMerge -WorkflowText $workflowText)
+            } else {
+                Test-LegacyMergeAutomation -WorkflowText $workflowText
+            }
+        if ($isLegacy) {
+            $remoteLegacyMergeWorkflows.Add($path) | Out-Null
+        }
+    }
     $branchSha =
         if ([string]::IsNullOrWhiteSpace($CheckSha)) {
             $commit = Invoke-GhJson -Arguments @(
@@ -154,6 +537,8 @@ function Get-LiveSnapshot {
 
     $activeRulesStatus = 'available'
     $activeRules = @()
+    $repositoryRulesetsStatus = 'available'
+    $repositoryRulesets = @()
     $activeRulesOutput = & $GhCommand api --paginate --slurp `
         -H 'X-GitHub-Api-Version: 2026-03-10' `
         "repos/$resolvedRepository/rules/branches/${defaultBranch}?per_page=100" 2>&1
@@ -174,6 +559,31 @@ function Get-LiveSnapshot {
         } else {
             throw "Unable to inspect active default-branch rules: $message"
         }
+    }
+    if ($activeRulesStatus -ceq 'available') {
+        $rulesetsOutput = & $GhCommand api --paginate --slurp `
+            -H 'X-GitHub-Api-Version: 2026-03-10' `
+            "repos/$resolvedRepository/rulesets?includes_parents=true&targets=branch&per_page=100" 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $rulesetPages = ($rulesetsOutput -join "`n") | ConvertFrom-Json
+            $repositoryRulesets = @(
+                foreach ($page in @($rulesetPages)) {
+                    @($page)
+                }
+            )
+        } else {
+            $message = $rulesetsOutput -join "`n"
+            if (
+                [bool]$repositoryState.private -and
+                $message -match '(?i)upgrade.*pro|make this repository public'
+            ) {
+                $repositoryRulesetsStatus = 'unavailable-private-plan'
+            } else {
+                throw "Unable to inspect repository rulesets: $message"
+            }
+        }
+    } else {
+        $repositoryRulesetsStatus = $activeRulesStatus
     }
 
     $checkRuns = Invoke-GhJson -Arguments @(
@@ -205,6 +615,9 @@ function Get-LiveSnapshot {
         protection             = $protection
         activeRulesStatus      = $activeRulesStatus
         activeRules            = @($activeRules)
+        repositoryRulesetsStatus = $repositoryRulesetsStatus
+        repositoryRulesets     = @($repositoryRulesets)
+        remoteLegacyMergeWorkflows = @($remoteLegacyMergeWorkflows)
         checkRuns              = @($flattenedChecks)
         privateWorkflowPresent = $privateWorkflowPresent
     }
@@ -217,10 +630,27 @@ $snapshot =
         Get-Content (Resolve-Path $SnapshotPath) -Raw | ConvertFrom-Json
     }
 
+if (
+    $Apply -and
+    -not [string]::IsNullOrWhiteSpace($SnapshotPath) -and
+    -not $WhatIfPreference
+) {
+    throw 'Offline snapshots are plan-only and cannot be used with -Apply.'
+}
+if ($AuditProtectionDrift -and $Apply) {
+    throw '-AuditProtectionDrift cannot be combined with -Apply.'
+}
+
 if ([string]::IsNullOrWhiteSpace($Repository)) {
     $Repository = [string]$snapshot.repository
 }
 
+$repositoryRulesetsStatus =
+    if ($snapshot.PSObject.Properties.Name -contains 'repositoryRulesetsStatus') {
+        [string]$snapshot.repositoryRulesetsStatus
+    } else {
+        'unknown'
+    }
 $selectedMode =
     if ($DeliveryMode -ne 'Auto') {
         $DeliveryMode
@@ -233,7 +663,11 @@ $selectedMode =
 if ($selectedMode -eq 'WorkflowRun' -and -not [bool]$snapshot.private) {
     throw 'WorkflowRun delivery is only supported for private repositories.'
 }
-if ($selectedMode -eq 'Native' -and [string]$snapshot.protectionStatus -eq 'unavailable-private-plan') {
+if (
+    $selectedMode -eq 'Native' -and
+    [string]$snapshot.protectionStatus -eq 'unavailable-private-plan' -and
+    -not $AuditProtectionDrift
+) {
     throw 'Native delivery was requested but branch protection is unavailable for this private repository.'
 }
 
@@ -244,37 +678,200 @@ $successfulCheckNames = @(
         Sort-Object -Unique
 )
 $missingChecks = @($requiredChecks | Where-Object { $_ -notin $successfulCheckNames })
+$bootstrapBlockers = @(Get-EmptyBootstrapPrBlockers -ProjectRoot $ProjectRoot)
 
 $operations = [System.Collections.Generic.List[string]]::new()
 $status = 'ready'
 $nextAction = $null
+$effectiveControlRunner =
+    if (-not [string]::IsNullOrWhiteSpace($ControlRunner)) {
+        $ControlRunner
+    } elseif (-not [bool]$snapshot.private) {
+        'ubuntu-24.04'
+    } else {
+        $null
+    }
 $activeRules = @($snapshot.activeRules)
+$repositoryRulesets = @(
+    if ($snapshot.PSObject.Properties.Name -contains 'repositoryRulesets') {
+        @($snapshot.repositoryRulesets)
+    }
+)
+$rulesetConflict = (
+    $activeRules.Count -gt 0 -or
+    $repositoryRulesets.Count -gt 0 -or
+    ($selectedMode -eq 'Native' -and $repositoryRulesetsStatus -cne 'available')
+)
 
-if ($activeRules.Count -gt 0) {
+$driftProtectedChecks = @()
+$driftMissingProtectedChecks = @()
+$driftUnexpectedProtectedChecks = @()
+$driftReasons = [System.Collections.Generic.List[string]]::new()
+$driftStatus = 'not-applicable'
+
+if ($selectedMode -ceq 'Native') {
+    $expectedNativeChecks = @(
+        $requiredChecks | ForEach-Object {
+            [ordered]@{ context = [string]$_; app_id = 15368 }
+        }
+    )
+    if ([string]$snapshot.protectionStatus -ceq 'protected') {
+        $driftProtectedChecks = @(
+            @($snapshot.protection.required_status_checks.checks) |
+                Sort-Object `
+                    @{ Expression = { [string]$_.context } },
+                    @{ Expression = { [int]$_.app_id } }
+        )
+        $driftMissingProtectedChecks = @(
+            $expectedNativeChecks | Where-Object {
+                $ctx = [string]$_.context
+                $aid = [int]$_.app_id
+                -not ($driftProtectedChecks | Where-Object {
+                    [string]$_.context -ceq $ctx -and [int]$_.app_id -eq $aid
+                })
+            }
+        )
+        $driftUnexpectedProtectedChecks = @(
+            $driftProtectedChecks | Where-Object {
+                $ctx = [string]$_.context
+                $aid = [int]$_.app_id
+                -not ($expectedNativeChecks | Where-Object {
+                    [string]$_.context -ceq $ctx -and [int]$_.app_id -eq $aid
+                })
+            }
+        )
+        if ($driftMissingProtectedChecks.Count -gt 0) {
+            $driftReasons.Add(
+                "Missing protected checks: $(($driftMissingProtectedChecks | ForEach-Object { [string]$_.context }) -join ', ')"
+            ) | Out-Null
+        }
+        if ($driftUnexpectedProtectedChecks.Count -gt 0) {
+            $driftReasons.Add(
+                "Unexpected protected checks: $(($driftUnexpectedProtectedChecks | ForEach-Object { "$([string]$_.context):$([int]$_.app_id)" }) -join ', ')"
+            ) | Out-Null
+        }
+        $wrongAppIdChecks = @(
+            $driftProtectedChecks | Where-Object {
+                $ctx = [string]$_.context
+                $aid = [int]$_.app_id
+                ($requiredChecks -contains $ctx) -and $aid -ne 15368
+            }
+        )
+        if ($wrongAppIdChecks.Count -gt 0) {
+            $driftReasons.Add(
+                "Wrong app_id for checks: $(($wrongAppIdChecks | ForEach-Object { "$([string]$_.context):$([int]$_.app_id)" }) -join ', ')"
+            ) | Out-Null
+        }
+        $desiredProtection = Test-DesiredClassicProtection `
+            -Protection $snapshot.protection `
+            -ExpectedChecks $expectedNativeChecks
+        if (-not $desiredProtection) {
+            $driftReasons.Add('Protection safety contract violated') | Out-Null
+        }
+        $driftStatus = if ($driftReasons.Count -eq 0) { 'aligned' } else { 'drift' }
+    } elseif ([string]$snapshot.protectionStatus -ceq 'available-unprotected') {
+        $driftMissingProtectedChecks = @($expectedNativeChecks)
+        $driftReasons.Add('Default branch is unprotected') | Out-Null
+        $driftStatus = 'drift'
+    } else {
+        $driftStatus = 'not-applicable'
+    }
+
+    if (
+        $repositoryRulesetsStatus -cne 'available' -or
+        $activeRules.Count -gt 0 -or
+        $repositoryRulesets.Count -gt 0
+    ) {
+        $driftStatus = 'unverifiable'
+        if ($repositoryRulesetsStatus -cne 'available') {
+            $driftReasons.Add("Ruleset inspection is $repositoryRulesetsStatus") | Out-Null
+        }
+        if ($activeRules.Count -gt 0) {
+            $driftReasons.Add("$($activeRules.Count) active default-branch rule(s) from rulesets") | Out-Null
+        }
+        if ($repositoryRulesets.Count -gt 0) {
+            $driftReasons.Add("$($repositoryRulesets.Count) repository/inherited ruleset(s) present") | Out-Null
+        }
+    }
+} elseif ($selectedMode -ceq 'WorkflowRun') {
+    $driftStatus = 'not-applicable'
+}
+
+$legacyZeroReviewProtection = (
+    [string]$snapshot.protectionStatus -ceq 'protected' -and
+    (Test-LegacyZeroReviewProtection `
+        -ReviewRequirement $snapshot.protection.required_pull_request_reviews)
+)
+$legacyConversationGate = (
+    [string]$snapshot.protectionStatus -ceq 'protected' -and
+    $null -eq $snapshot.protection.required_pull_request_reviews -and
+    [bool]$snapshot.protection.required_conversation_resolution.enabled
+)
+$legacyPullRequestGate = (
+    $legacyZeroReviewProtection -or
+    $legacyConversationGate
+)
+$localLegacyMergeWorkflows = @(Get-LegacyMergeWorkflowPaths)
+$remoteLegacyMergeWorkflows = @($snapshot.remoteLegacyMergeWorkflows)
+$legacyMergeWorkflows = @(
+    $localLegacyMergeWorkflows + $remoteLegacyMergeWorkflows |
+        Sort-Object -Unique)
+
+if ($legacyMergeWorkflows.Count -gt 0) {
     $status = 'manual'
-    $nextAction = 'Active repository or inherited rulesets apply to the default branch. Reconcile them manually; Genesis will not mutate overlapping policy.'
+    $nextAction = "Remove legacy PR merge automation before activation: $($legacyMergeWorkflows -join ', ')."
+} elseif ($rulesetConflict) {
+    $status = 'manual'
+    $nextAction = 'Repository, inherited, active, disabled, or evaluate rulesets apply to the default branch. Reconcile them manually; Genesis native delivery does not mutate rulesets.'
 } elseif ($selectedMode -eq 'Native' -and $missingChecks.Count -gt 0) {
     $status = 'deferred'
-    $nextAction = "Run the required workflows, then rerun with -CheckSha <sha>. Missing: $($missingChecks -join ', ')."
+    $nextAction = Get-NativeMissingChecksNextAction `
+        -MissingChecks $missingChecks `
+        -BootstrapBlockers $bootstrapBlockers
 } elseif ($selectedMode -eq 'WorkflowRun' -and -not [bool]$snapshot.privateWorkflowPresent) {
     $status = 'deferred'
     $nextAction = 'Install and merge .github/workflows/private-auto-merge.yml, then rerun.'
     if (Test-Path $installerPath) {
         if ($Apply) {
-            & $installerPath -ProjectRoot $ProjectRoot -Confirm:$false | Out-Null
+            if ($WhatIfPreference) {
+                & $installerPath `
+                    -ProjectRoot $ProjectRoot `
+                    -WhatIf |
+                    Out-Null
+            } elseif ($PSCmdlet.ShouldProcess(
+                $ProjectRoot,
+                'Install the private exact-SHA merge workflow'
+            )) {
+                & $installerPath `
+                    -ProjectRoot $ProjectRoot `
+                    -Confirm:$false |
+                    Out-Null
+            }
         } else {
             & $installerPath -ProjectRoot $ProjectRoot -WhatIf | Out-Null
         }
     }
 }
 
-if ($status -eq 'ready') {
+if ($status -ceq 'ready' -and
+    [string]::IsNullOrWhiteSpace($effectiveControlRunner)) {
+    $status = 'manual'
+    $nextAction =
+        'Rerun with -ControlRunner <approved-capability>. Use ubuntu-24.04 only for explicit hosted recovery.'
+}
+
+if ($status -eq 'ready' -and -not $AuditProtectionDrift) {
     $reviewPolicyValue =
         if ($ReviewPolicy -eq 'CopilotOneApproval') {
             'copilot-one-approval'
         } else {
             'none'
         }
+    if (-not [string]::IsNullOrWhiteSpace($effectiveControlRunner)) {
+        $operations.Add(
+            "Set REPOSITORY_AUTOMATION_CONTROL_RUNNER=$effectiveControlRunner"
+        ) | Out-Null
+    }
     $operations.Add('Configure squash-only repository merge settings') | Out-Null
     $operations.Add('Set read-only Actions workflow permissions') | Out-Null
     if (-not [bool]$snapshot.private) {
@@ -284,46 +881,43 @@ if ($status -eq 'ready') {
     $operations.Add("Set GENESIS_REVIEW_POLICY=$reviewPolicyValue") | Out-Null
     if ($selectedMode -eq 'Native') {
         if ([string]$snapshot.protectionStatus -eq 'protected') {
-            $existingChecks = @($snapshot.protection.required_status_checks.checks)
-            $missingProtectionChecks = @(
-                $requiredChecks |
-                    Where-Object {
-                        $requiredCheck = $_
-                        -not ($existingChecks | Where-Object {
-                            [string]$_.context -ceq $requiredCheck -and
-                            [int]$_.app_id -eq 15368
-                        })
-                    }
+            $baseProtectionIsSafe = Test-ClassicProtectionSafety `
+                -Protection $snapshot.protection `
+                -RequiredChecks $requiredChecks
+            $reviewRequirement = $snapshot.protection.required_pull_request_reviews
+            $desiredReviewState = (
+                $null -eq $reviewRequirement -and
+                -not [bool]$snapshot.protection.required_conversation_resolution.enabled
             )
-            $reviewBypasses = $snapshot.protection.required_pull_request_reviews.bypass_pull_request_allowances
-            $reviewBypassActors = @(
-                if ($null -ne $reviewBypasses) {
-                    @($reviewBypasses.users) | Where-Object { $null -ne $_ }
-                    @($reviewBypasses.teams) | Where-Object { $null -ne $_ }
-                    @($reviewBypasses.apps) | Where-Object { $null -ne $_ }
-                }
-            )
-            $hasReviewBypasses = $reviewBypassActors.Count -gt 0
             $compatibleProtection = (
-                $missingProtectionChecks.Count -eq 0 -and
-                [bool]$snapshot.protection.required_status_checks.strict -and
-                [bool]$snapshot.protection.enforce_admins.enabled -and
-                $null -ne $snapshot.protection.required_pull_request_reviews -and
-                -not $hasReviewBypasses -and
-                [bool]$snapshot.protection.required_conversation_resolution.enabled -and
-                -not [bool]$snapshot.protection.allow_force_pushes.enabled -and
-                -not [bool]$snapshot.protection.allow_deletions.enabled
+                $baseProtectionIsSafe -and
+                ($desiredReviewState -or $legacyPullRequestGate)
             )
             if (-not $compatibleProtection) {
                 throw 'Existing branch protection differs from the Genesis safety contract; update it manually rather than allowing Genesis to overwrite it.'
             }
-            $operations.Add('Keep existing compatible branch protection') | Out-Null
+            if ($legacyPullRequestGate) {
+                $operations.Add('Recreate legacy PR gate under temporary check protection') | Out-Null
+            } else {
+                $operations.Add('Keep existing compatible branch protection') | Out-Null
+            }
         } else {
             $operations.Add('Create strict default-branch protection with required checks') | Out-Null
         }
-        $operations.Add('Enable native repository auto-merge') | Out-Null
+        if ($stackedPullRequests) {
+            $operations.Add('Enable native repository auto-merge for standalone pull requests') |
+                Out-Null
+            $operations.Add('Use GitHub-native stack checks and atomic merge or merge queue') |
+                Out-Null
+        } else {
+            $operations.Add('Enable native repository auto-merge') | Out-Null
+        }
         $operations.Add('Set GENESIS_DELIVERY_MODEL=native') | Out-Null
     } else {
+        if ($stackedPullRequests) {
+            $operations.Add('Use contract-validated asynchronous exact-SHA stack merge') |
+                Out-Null
+        }
         $operations.Add('Set GENESIS_DELIVERY_MODEL=workflow-run') | Out-Null
     }
 }
@@ -340,9 +934,25 @@ $result = [ordered]@{
     operations       = @($operations)
     draftMode        = $draftMode
     reviewPolicy     = $ReviewPolicy
+    controlRunner    = $effectiveControlRunner
     activeRulesStatus = [string]$snapshot.activeRulesStatus
     activeRules      = @($activeRules)
+    repositoryRulesetsStatus = $repositoryRulesetsStatus
+    repositoryRulesets = @($repositoryRulesets)
+    legacyZeroReviewProtection = $legacyZeroReviewProtection
+    legacyConversationGate = $legacyConversationGate
+    legacyPullRequestGate = $legacyPullRequestGate
+    localLegacyMergeWorkflows = @($localLegacyMergeWorkflows)
+    remoteLegacyMergeWorkflows = @($remoteLegacyMergeWorkflows)
+    legacyMergeWorkflows = @($legacyMergeWorkflows)
     nextAction       = $nextAction
+    protectionDrift  = [ordered]@{
+        status                    = $driftStatus
+        protectedChecks           = @($driftProtectedChecks)
+        missingProtectedChecks    = @($driftMissingProtectedChecks)
+        unexpectedProtectedChecks = @($driftUnexpectedProtectedChecks)
+        reasons                   = @($driftReasons)
+    }
 }
 
 if (-not $Apply -or $status -ne 'ready') {
@@ -361,7 +971,67 @@ if (-not $PSCmdlet.ShouldProcess(
     return
 }
 
-Write-Host "[1/3] Applying squash-only repository settings"
+if ($selectedMode -eq 'Native') {
+    $applyRulesetPages = Invoke-GhJson -Arguments @(
+        'api',
+        '--paginate',
+        '--slurp',
+        '-H', 'X-GitHub-Api-Version: 2026-03-10',
+        "repos/$Repository/rulesets?includes_parents=true&targets=branch&per_page=100")
+    $applyRulesets = @(
+        foreach ($page in @($applyRulesetPages)) {
+            @($page)
+        }
+    )
+    if ($applyRulesets.Count -gt 0) {
+        throw 'Rulesets changed after planning; rerun before applying native delivery.'
+    }
+    $applyProtectionStatus = 'available-unprotected'
+    $applyProtection = $null
+    $applyProtectionOutput = & $GhCommand api `
+        -H 'X-GitHub-Api-Version: 2026-03-10' `
+        "repos/$Repository/branches/$($snapshot.defaultBranch)/protection" 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $applyProtectionStatus = 'protected'
+        $applyProtection = ($applyProtectionOutput -join "`n") |
+            ConvertFrom-Json
+    } elseif (($applyProtectionOutput -join "`n") -notmatch 'HTTP 404') {
+        throw "Unable to revalidate classic protection before apply: $($applyProtectionOutput -join "`n")"
+    }
+    if ($applyProtectionStatus -cne [string]$snapshot.protectionStatus) {
+        throw 'Classic protection changed after planning; rerun before applying delivery settings.'
+    }
+    if (
+        $applyProtectionStatus -ceq 'protected' -and
+        (
+            ($applyProtection | ConvertTo-Json -Depth 20 -Compress) -cne
+                ($snapshot.protection | ConvertTo-Json -Depth 20 -Compress)
+        )
+    ) {
+        throw 'Classic protection changed after planning; rerun before applying delivery settings.'
+    }
+}
+
+Write-Host "[1/4] Configuring repository control capability"
+& $GhCommand variable set REPOSITORY_AUTOMATION_CONTROL_RUNNER `
+    --repo $Repository `
+    --body $effectiveControlRunner *> $null
+if ($LASTEXITCODE -ne 0) {
+    throw 'Failed to set REPOSITORY_AUTOMATION_CONTROL_RUNNER.'
+}
+$controlRunnerOutput = @(
+    & $GhCommand variable get REPOSITORY_AUTOMATION_CONTROL_RUNNER `
+        --repo $Repository `
+        --json value `
+        --jq '.value' 2>&1
+)
+if ($LASTEXITCODE -ne 0 -or
+    ($controlRunnerOutput -join "`n").Trim() -cne
+        $effectiveControlRunner) {
+    throw 'Failed to verify REPOSITORY_AUTOMATION_CONTROL_RUNNER.'
+}
+
+Write-Host "[2/4] Applying squash-only repository settings"
 $autoMergeValue = if ($selectedMode -eq 'Native') { 'true' } else { 'false' }
 & $GhCommand api --method PATCH `
     -H 'X-GitHub-Api-Version: 2026-03-10' `
@@ -375,37 +1045,253 @@ $autoMergeValue = if ($selectedMode -eq 'Native') { 'true' } else { 'false' }
     -f squash_merge_commit_message=PR_BODY *> $null
 if ($LASTEXITCODE -ne 0) { throw 'Failed to configure repository merge settings.' }
 
-Write-Host "[2/3] Applying delivery model '$selectedMode'"
+Write-Host "[3/4] Applying delivery model '$selectedMode'"
 if ($selectedMode -eq 'Native' -and [string]$snapshot.protectionStatus -ne 'protected') {
     $checks = @(
         $requiredChecks | ForEach-Object {
             [ordered]@{ context = $_; app_id = 15368 }
         }
     )
-    $protectionBody = [ordered]@{
-        required_status_checks = [ordered]@{ strict = $true; checks = $checks }
-        enforce_admins = $true
-        required_pull_request_reviews = [ordered]@{
-            dismiss_stale_reviews = $false
-            require_code_owner_reviews = $false
-            required_approving_review_count = 0
-            require_last_push_approval = $false
-        }
-        restrictions = $null
-        required_linear_history = $false
-        allow_force_pushes = $false
-        allow_deletions = $false
-        block_creations = $false
-        required_conversation_resolution = $true
-        lock_branch = $false
-        allow_fork_syncing = $false
-    }
+    $protectionBody = New-ClassicProtectionBody -Checks $checks
     $protectionBody | ConvertTo-Json -Depth 8 -Compress |
         & $GhCommand api --method PUT `
             -H 'X-GitHub-Api-Version: 2026-03-10' `
             "repos/$Repository/branches/$($snapshot.defaultBranch)/protection" `
             --input - *> $null
     if ($LASTEXITCODE -ne 0) { throw 'Failed to configure branch protection.' }
+    $createdProtection = Invoke-GhJson -Arguments @(
+        'api',
+        '-H', 'X-GitHub-Api-Version: 2026-03-10',
+        "repos/$Repository/branches/$($snapshot.defaultBranch)/protection")
+    if (-not (Test-DesiredClassicProtection `
+        -Protection $createdProtection `
+        -ExpectedChecks $checks)) {
+        throw 'GitHub did not return the expected check-only branch protection.'
+    }
+}
+if ($selectedMode -eq 'Native' -and $legacyPullRequestGate) {
+    $currentRulesetPages = Invoke-GhJson -Arguments @(
+        'api',
+        '--paginate',
+        '--slurp',
+        '-H', 'X-GitHub-Api-Version: 2026-03-10',
+        "repos/$Repository/rulesets?includes_parents=true&targets=branch&per_page=100")
+    $currentRulesets = @(
+        foreach ($page in @($currentRulesetPages)) {
+            @($page)
+        }
+    )
+    if ($currentRulesets.Count -gt 0) {
+        throw 'Rulesets changed after planning; rerun before migrating branch protection.'
+    }
+
+    $currentProtection = Invoke-GhJson -Arguments @(
+        'api',
+        '-H', 'X-GitHub-Api-Version: 2026-03-10',
+        "repos/$Repository/branches/$($snapshot.defaultBranch)/protection")
+    $currentLegacyGate = (
+        (Test-LegacyZeroReviewProtection `
+            -ReviewRequirement $currentProtection.required_pull_request_reviews) -or
+        (
+            $null -eq $currentProtection.required_pull_request_reviews -and
+            [bool]$currentProtection.required_conversation_resolution.enabled
+        )
+    )
+    if (
+        -not (Test-ClassicProtectionSafety `
+            -Protection $currentProtection `
+            -RequiredChecks $requiredChecks) -or
+        -not $currentLegacyGate
+    ) {
+        throw 'Classic protection changed after planning; rerun before migrating it.'
+    }
+
+    $originalProtectionJson = $currentProtection |
+        ConvertTo-Json -Depth 20 -Compress
+    $cutoverBody = [ordered]@{
+        name = 'Genesis protection cutover'
+        target = 'branch'
+        enforcement = 'active'
+        bypass_actors = @()
+        conditions = [ordered]@{
+            ref_name = [ordered]@{
+                include = @('~DEFAULT_BRANCH')
+                exclude = @()
+            }
+        }
+        rules = @(
+            [ordered]@{
+                type = 'required_status_checks'
+                parameters = [ordered]@{
+                    strict_required_status_checks_policy = $true
+                    do_not_enforce_on_create = $false
+                    required_status_checks = @(
+                        $currentProtection.required_status_checks.checks |
+                            ForEach-Object {
+                                [ordered]@{
+                                    context = [string]$_.context
+                                    integration_id = [int]$_.app_id
+                                }
+                            }
+                    )
+                }
+            },
+            [ordered]@{ type = 'deletion' },
+            [ordered]@{ type = 'non_fast_forward' }
+        )
+    }
+
+    $cutoverRulesetId = $null
+    $classicProtectionRemoved = $false
+    $classicProtectionRestored = $false
+    $classicProtectionVerified = $false
+    try {
+        $cutoverOutput = $cutoverBody | ConvertTo-Json -Depth 10 -Compress |
+            & $GhCommand api --method POST `
+                -H 'X-GitHub-Api-Version: 2026-03-10' `
+                "repos/$Repository/rulesets" `
+                --input -
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to create temporary cutover protection.'
+        }
+        $cutoverRuleset = ($cutoverOutput -join "`n") | ConvertFrom-Json
+        $cutoverRulesetId = [int64]$cutoverRuleset.id
+        if ($cutoverRulesetId -le 0) {
+            throw 'Temporary cutover protection did not return a ruleset ID.'
+        }
+
+        $cutoverActive = $false
+        $cutoverDeadline = [DateTimeOffset]::UtcNow.AddSeconds(30)
+        do {
+            $activeRulePages = Invoke-GhJson -Arguments @(
+                'api',
+                '--paginate',
+                '--slurp',
+                '-H', 'X-GitHub-Api-Version: 2026-03-10',
+                "repos/$Repository/rules/branches/$($snapshot.defaultBranch)?per_page=100")
+            $activeRulesNow = @(
+                foreach ($page in @($activeRulePages)) {
+                    @($page)
+                }
+            )
+            $cutoverTypes = @(
+                foreach ($rule in $activeRulesNow) {
+                    if ([int64]$rule.ruleset_id -eq $cutoverRulesetId) {
+                        [string]$rule.type
+                    }
+                }
+            ) | Sort-Object
+            $otherActiveRules = @(
+                $activeRulesNow |
+                    Where-Object {
+                        [int64]$_.ruleset_id -ne $cutoverRulesetId
+                    }
+            )
+            $cutoverActive = (
+                ($cutoverTypes -join ',') -ceq
+                    'deletion,non_fast_forward,required_status_checks' -and
+                $otherActiveRules.Count -eq 0
+            )
+            if (-not $cutoverActive) {
+                Start-Sleep -Seconds 1
+            }
+        } while (
+            -not $cutoverActive -and
+            [DateTimeOffset]::UtcNow -lt $cutoverDeadline
+        )
+        if (-not $cutoverActive) {
+            throw 'Temporary cutover protection did not become active within 30 seconds.'
+        }
+
+        $beforeDelete = Invoke-GhJson -Arguments @(
+            'api',
+            '-H', 'X-GitHub-Api-Version: 2026-03-10',
+            "repos/$Repository/branches/$($snapshot.defaultBranch)/protection")
+        if (
+            ($beforeDelete | ConvertTo-Json -Depth 20 -Compress) -cne
+                $originalProtectionJson
+        ) {
+            throw 'Classic protection changed during cutover; migration was stopped.'
+        }
+
+        $deleteOutput = & $GhCommand api --method DELETE `
+            -H 'X-GitHub-Api-Version: 2026-03-10' `
+            "repos/$Repository/branches/$($snapshot.defaultBranch)/protection" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            $afterDeleteOutput = & $GhCommand api `
+                -H 'X-GitHub-Api-Version: 2026-03-10' `
+                "repos/$Repository/branches/$($snapshot.defaultBranch)/protection" 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                throw "Failed to remove the legacy classic protection: $($deleteOutput -join "`n")"
+            }
+            if (($afterDeleteOutput -join "`n") -notmatch 'HTTP 404') {
+                throw "Classic protection deletion became indeterminate: $($deleteOutput -join "`n")"
+            }
+        }
+        $classicProtectionRemoved = $true
+
+        $replacementBody = New-ClassicProtectionBody `
+            -Checks @($currentProtection.required_status_checks.checks)
+        $replacementBody | ConvertTo-Json -Depth 8 -Compress |
+            & $GhCommand api --method PUT `
+                -H 'X-GitHub-Api-Version: 2026-03-10' `
+                "repos/$Repository/branches/$($snapshot.defaultBranch)/protection" `
+                --input - *> $null
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to recreate check-only classic protection.'
+        }
+        $classicProtectionRestored = $true
+
+        $replacementProtection = Invoke-GhJson -Arguments @(
+            'api',
+            '-H', 'X-GitHub-Api-Version: 2026-03-10',
+            "repos/$Repository/branches/$($snapshot.defaultBranch)/protection")
+        if (-not (Test-DesiredClassicProtection `
+            -Protection $replacementProtection `
+            -ExpectedChecks @($currentProtection.required_status_checks.checks))) {
+            throw 'Recreated classic protection does not match the check-only contract.'
+        }
+        $classicProtectionVerified = $true
+
+        & $GhCommand api --method DELETE `
+            -H 'X-GitHub-Api-Version: 2026-03-10' `
+            "repos/$Repository/rulesets/$cutoverRulesetId" *> $null
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Classic protection is restored, but temporary cutover protection could not be removed.'
+        }
+        $cutoverRulesetId = $null
+    } catch {
+        if ($null -ne $cutoverRulesetId) {
+            $safeToRemoveCutover = $false
+            $cleanupProtectionOutput = & $GhCommand api `
+                -H 'X-GitHub-Api-Version: 2026-03-10' `
+                "repos/$Repository/branches/$($snapshot.defaultBranch)/protection" 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                $cleanupProtection = ($cleanupProtectionOutput -join "`n") |
+                    ConvertFrom-Json
+                $safeToRemoveCutover = (
+                    (Test-DesiredClassicProtection `
+                        -Protection $cleanupProtection `
+                        -ExpectedChecks @(
+                            $currentProtection.required_status_checks.checks
+                        )) -or
+                    (
+                        -not $classicProtectionRemoved -and
+                        (
+                            ($cleanupProtection | ConvertTo-Json -Depth 20 -Compress) -ceq
+                                $originalProtectionJson
+                        )
+                    )
+                )
+            }
+            if ($safeToRemoveCutover) {
+                & $GhCommand api --method DELETE `
+                    -H 'X-GitHub-Api-Version: 2026-03-10' `
+                    "repos/$Repository/rulesets/$cutoverRulesetId" *> $null
+            }
+        }
+        throw
+    }
 }
 
 $workflowPermissionsBody = [ordered]@{
@@ -445,7 +1331,7 @@ if ($LASTEXITCODE -ne 0) { throw 'Failed to set GENESIS_REVIEW_POLICY.' }
     --body $draftMode *> $null
 if ($LASTEXITCODE -ne 0) { throw 'Failed to set CI_DRAFT_MODE.' }
 
-Write-Host "[3/3] Recording default branch locally"
+Write-Host "[4/4] Recording default branch locally"
 git -C $ProjectRoot config genesis.defaultBranch ([string]$snapshot.defaultBranch)
 
 $result.status = 'applied'


### PR DESCRIPTION
Enables same-repository stacked pull requests and realigns this repository's
delivery assets with the Genesis contract at origin `main` (`b4eefe0e`).

## Why

Requested capabilities: PR-pattern workflow, protected default branch, native
stacked PRs, native auto-merge, with `enforce_admins` left **canonical (true)**
— no administrator bypass. A blocked PR must be fixed by making its checks
pass, not by overriding protection.

## What changed

**Stacked pull requests.** Installs the `github-stacked-pr-delivery` component,
which uses GitHub's native stack object (`.stack.number/size/position/base`).
Linear, same-repository, max 8 layers, bottom layer targets the default branch.
Fork PRs remain ordinary PRs. See `docs/stacked-pull-requests.md`.

**New required gate `PR base`.** Deliberately the only PR workflow with no
branch filter, so a PR targeting neither the default branch nor a valid stack
layer fails visibly instead of silently receiving zero checks.

**Review policy is now a job, not a POSTed check run.** Previously the job was
named `Evaluate review policy` and a step POSTed a check run named
`Review policy`. That means a run cancelled before the publishing step creates
**no `Review policy` check at all** for that SHA. The canonical form names the
job `Review policy`, and GitHub creates a job's check run unconditionally —
including on cancellation. `ncosentino/eve-client` already uses this form.

**CI** gains the `stacked` PR type and `merge_group` trigger; the summary job
moves `always()` → `!cancelled()` so a cancelled run stops reporting a failure.

**Refreshed vendored assets.** `Configure-GitHubDelivery.ps1` was ~3x out of
date (17.5KB → 51KB); `genesis-delivery.schema.json` also refreshed.

## Scope boundary

Branch filters are written as `master`. Renaming to `main` — which every
Genesis template and every healthy sibling repo uses — is a **separate
deliverable** so each can be validated independently.

## Validation

- Build **0 warnings / 0 errors**; tests **897 total / 896 passed / 1 skipped /
  0 failed** (the skip is a pre-existing documented flake).
- All 5 workflows parse (PyYAML); job names resolve to `PR base`, `PR title`,
  `Review policy`, and the CI gate expression.
- `genesis-delivery.json` validates against the canonical schema (`Test-Json`).
- Confirmed no residual check-run POST that could duplicate `Review policy`.
- Installed workflows verified **byte-identical to the component** after
  default-branch normalization.

## Known upstream gaps (not defects in this change)

`Test-DeliveryAlignment.ps1` reports 7 errors that are **structural upstream
limitations**, verified by reading the auditor source:

1. **4× `ASSET_DRIFT`** — the auditor compares only against `seed/` assets and
   has no awareness of the `github-stacked-pr-delivery` component. Installing
   the component therefore *always* trips this. Note `NormalizeDefaultBranch`
   is applied to `pr-title`/`pr-review-policy`, so `master` is **not** the
   cause; the rename PR will not resolve these.
2. **3× `UNSAFE_FORK_RUNNER`** — the component's own `runs-on` puts the
   `merge_group` branch before the fork override, so the auditor's
   "leading hosted-fork override" regex does not match. `-ApprovedIndirectRunnerPath`
   only suppresses `INDIRECT_RUNNER_ROUTE`, not this code.

**Fork-safety trace** (required before accepting #2): for a fork `pull_request`,
clause 1 (`merge_group`) is false; clause 2
(`head.repo.full_name != github.repository`) is true and yields `ubuntu-24.04`;
`||` short-circuits, so the `vars.*` clauses are unreachable. A fork cannot emit
`merge_group` (it comes from this repo's merge queue). Additionally
`REPOSITORY_AUTOMATION_CONTROL_RUNNER` is **not defined** here, so every branch
falls back to `ubuntu-24.04`. I kept the expression upstream-verbatim rather
than reordering, because putting the fork check first would make
`github.event.pull_request` null on `merge_group` and wrongly force hosted.

Both warrant upstream issues in `ncosentino/genesis`.

## Not done here

Remote activation. Applying protection/auto-merge via
`Configure-GitHubDelivery.ps1 -Apply` requires separate explicit approval and
must happen **after** this merges, since the audit currently reports
`status: deferred` — the new `PR base` context has never been observed on a SHA.

## Self-assessment

| Priority | Item | Assessment |
|---|---|---|
| HIGH | Omitted behavior | None. Remote activation is intentionally deferred and called out above. |
| HIGH | Implementation gaps | None in scope. `master`→`main` is a deliberate separate deliverable. |
| HIGH | Test results | Build 0/0; tests 897/896/1 skipped/0 failed. Numbers above. |
| MEDIUM | Tech debt | 7 auditor errors remain, all traced to upstream gaps; `isAligned: False` is unreachable for any repo using this component. |
| MEDIUM | Missing coverage | **The end-to-end flow is unproven.** Nothing here demonstrates draft → ready → stacked → auto-merge on real infrastructure; that needs a live test after activation. The `Review policy` fix is reasoned from workflow semantics, not yet observed green. |
| MEDIUM | Weak assertions | Validation is parse/schema-level plus the repo suite; no workflow behavior is executed locally. |
| LOW | Assumptions | GitHub's native stack object and `stacked` PR event type are available to this repository; unverified until a real stack is opened. |
