### PR TITLE
docs: remove stack smoke test marker

### DIFF
--- a/docs/stack-smoke-test.md
+++ b/docs/stack-smoke-test.md
@@ -1,5 +1,0 @@
-# Stack smoke test
-
-Temporary marker added by layer 1 of a two-layer stack test.
-Layer 2 removes this file, so the merged result is a no-op.
-


### PR DESCRIPTION
Layer 2 of 2 in a stacked-PR smoke test. Based on the layer 1 branch rather than the default branch. Removes the marker layer 1 added.