### PR TITLE
chore: complete the rename to main

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+paths:
+  .github/workflows/*.yml:
+    ignore:
+      # actionlint 1.7.12 predates GitHub's `stacked` pull_request activity type
+      # and rejects it, but GitHub accepts and dispatches it: PR base, PR title,
+      # and CI all run from triggers that declare it. Remove this waiver once
+      # actionlint learns the type.
+      - 'invalid activity type "stacked"'

--- a/.github/genesis-delivery.json
+++ b/.github/genesis-delivery.json
@@ -2,7 +2,7 @@
   "$schema": "./genesis-delivery.schema.json",
   "schemaVersion": 1,
   "template": "nuget-library",
-  "defaultBranch": "master",
+  "defaultBranch": "main",
   "ciWorkflow": "CI",
   "requiredChecks": [
     "CI",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,12 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, stacked]
   merge_group:
     types: [checks_requested]
   push:
-    branches: [main, master]
+    branches: [main]
   workflow_dispatch:
     inputs:
       validation_scope:
@@ -46,6 +46,16 @@ jobs:
           case "$scope" in full|subset|ready-only) ;; *) exit 1 ;; esac
           if [ "$scope" = "subset" ]; then scope=full; fi
           echo "scope=$scope" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v7
+
+      - name: Lint workflows
+        # actionlint 1.7.12 predates GitHub's `stacked` pull_request activity
+        # type and rejects it, but GitHub accepts and dispatches it. Waive that
+        # one rule rather than dropping the trigger the delivery contract needs.
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color -ignore 'invalid activity type "stacked"'
 
   build-and-test:
     needs: validation-plan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,11 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Lint workflows
-        # actionlint 1.7.12 predates GitHub's `stacked` pull_request activity
-        # type and rejects it, but GitHub accepts and dispatches it. Waive that
-        # one rule rather than dropping the trigger the delivery contract needs.
+        # A plain YAML parse accepts an invalid workflow; only an Actions-aware
+        # linter rejects one. Waivers live in .github/actionlint.yaml.
         uses: docker://rhysd/actionlint:1.7.12
         with:
-          args: -color -ignore 'invalid activity type "stacked"'
+          args: -color
 
   build-and-test:
     needs: validation-plan

--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -3,10 +3,10 @@ run-name: "${{ github.event_name == 'merge_group' && format('Review policy for m
 
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main]
     types: [stacked]
   pull_request_target:
-    branches: [main, master]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   pull_request_review:
     types: [submitted, dismissed]

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,7 +2,7 @@ name: PR title
 
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main]
     types: [opened, edited, synchronize, reopened, ready_for_review, stacked]
   merge_group:
     types: [checks_requested]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,24 +68,24 @@ The exact, machine-readable delivery contract lives in
 source of truth for required checks, draft behavior, and workflow roles. The
 notes below summarize it and never override it.
 
-- `master` is this repository's default branch. Every pull request targets the
+- `main` is this repository's default branch. Every pull request targets the
   default branch unless it is a layer in a stacked pull request.
 - Local commits are unrestricted checkpoints — commit as often as is useful and
   do not stop to assemble a self-assessment for one. The assessment gate lives
   at ready delivery, not at `git commit`. Local commits belong on feature
   branches. Each clone must activate the repository hook with
   `git config core.hooksPath .githooks` and
-  `git config genesis.defaultBranch master`. With that local configuration
-  active, `.githooks/pre-push` blocks updates or deletion of `master`; deliver
+  `git config genesis.defaultBranch main`. With that local configuration
+  active, `.githooks/pre-push` blocks updates or deletion of `main`; deliver
   changes through pull requests. `.githooks/commit-msg` enforces the
   conventional-commit subject format on every commit.
-- Target `master` unless you are deliberately building a stacked pull request.
+- Target `main` unless you are deliberately building a stacked pull request.
   This repository enables same-repository stacked pull requests through the
   `github-stacked-pr-delivery` component; see
   [docs/stacked-pull-requests.md](docs/stacked-pull-requests.md) for the rules.
   A stack is linear, stays in this repository, is at most eight layers, and its
-  bottom layer targets `master`. Fork pull requests remain ordinary pull
-  requests targeting `master`.
+  bottom layer targets `main`. Fork pull requests remain ordinary pull
+  requests targeting `main`.
 - Run targeted checks while iterating and the full repository validation before
   delivery. This public repository uses GitHub-hosted runners; no self-hosted
   runner route is declared in `.github/genesis-delivery.json`.
@@ -97,9 +97,9 @@ notes below summarize it and never override it.
   the stable required `CI` check.
 - The required merge gates are `CI`, `PR base`, `PR title`, and `Review policy`.
   `PR base` is deliberately the only pull-request workflow with no branch
-  filter, so a pull request that targets neither `master` nor a valid stack
+  filter, so a pull request that targets neither `main` nor a valid stack
   layer fails visibly instead of silently receiving no checks at all.
-- `enforce_admins` is enabled on `master`, matching the Genesis contract. There
+- `enforce_admins` is enabled on `main`, matching the Genesis contract. There
   is no administrator bypass: a blocked pull request is fixed by making its
   required checks pass, not by overriding protection.
 - When `GENESIS_REVIEW_POLICY=copilot-one-approval`, a ready Copilot-authored

--- a/src/NexusLabs.CodeAnalysis.Testing.TUnit/NexusLabs.CodeAnalysis.Testing.TUnit.csproj
+++ b/src/NexusLabs.CodeAnalysis.Testing.TUnit/NexusLabs.CodeAnalysis.Testing.TUnit.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Description>TUnit-flavored IVerifier implementation for Microsoft.CodeAnalysis.Testing. Pair with CSharpAnalyzerTest&lt;TAnalyzer, TUnitVerifier&gt; (or similar) to get the full Roslyn analyzer test harness in TUnit-based projects, where no Microsoft.CodeAnalysis.Testing.Verifiers.TUnit package exists upstream.</Description>
-    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/main/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NexusLabs.Data.Sql.MySql/NexusLabs.Data.Sql.MySql.csproj
+++ b/src/NexusLabs.Data.Sql.MySql/NexusLabs.Data.Sql.MySql.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Description>MySQL provider implementation for NexusLabs.Data.Sql. Provides MySqlConnectionFactory and MySQL-specific configuration; concrete adapter types remain internal so the implementation can be swapped without a breaking API change.</Description>
-    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/main/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NexusLabs.Data.Sql/NexusLabs.Data.Sql.csproj
+++ b/src/NexusLabs.Data.Sql/NexusLabs.Data.Sql.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Description>Provider-agnostic decorators and helpers for the async ADO.NET interface shapes defined in NexusLabs.Framework. Includes connection lease (pool-size limiting with timeout-bounded acquisition and a ConnectionPoolExhaustedException), open-tracking diagnostics, structured logging command wrapper, and a predicate-based connection factory.</Description>
-    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/main/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NexusLabs.Framework.Analyzers/DiagnosticDescriptors.cs
+++ b/src/NexusLabs.Framework.Analyzers/DiagnosticDescriptors.cs
@@ -9,7 +9,7 @@ internal static class DiagnosticDescriptors
     private const string PerformanceCategory = "Performance";
 
     private const string HelpLinkBase =
-        "https://github.com/ncosentino/NexusLabs.Framework/blob/master/docs/analyzers/";
+        "https://github.com/ncosentino/NexusLabs.Framework/blob/main/docs/analyzers/";
 
     public static readonly DiagnosticDescriptor DoNotUseConsoleWrite = new(
         id: "NLF0001",

--- a/src/NexusLabs.Framework.Analyzers/NexusLabs.Framework.Analyzers.csproj
+++ b/src/NexusLabs.Framework.Analyzers/NexusLabs.Framework.Analyzers.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Roslyn analyzers, diagnostic suppressor, and code fixes for codebase hygiene and correct use of NexusLabs.Framework types. Includes a TransfersOwnership suppressor for IDisposableAnalyzers IDISP007. Test-specific analyzers ship separately in NexusLabs.Xunit.Assertions.Analyzers; data-layer analyzers ship separately in NexusLabs.Data.Sql.Analyzers.</Description>
-    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/main/CHANGELOG.md</PackageReleaseNotes>
 
     <IsRoslynComponent>true</IsRoslynComponent>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>

--- a/src/NexusLabs.Framework/NexusLabs.Framework.csproj
+++ b/src/NexusLabs.Framework/NexusLabs.Framework.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Description>Cross-cutting C# utilities for Nexus Software Labs projects: result pattern (Tried/TriedEx/TriedNullEx + Safely + Try orchestration) with optional disposal of disposable wrapped values, [TransfersOwnership] ownership-transfer attribute, stream wrappers (StreamWithLength, ReadOnlySubstream, StreamPump), self-deleting temporary file/directory primitives (ITemporaryFile/ITemporaryDirectory + factories) with a pluggable delete-resilience seam, ArrayPool renting handles (RentedSpan ref struct for sync + RentedMemory owner for async, via RentSpan/RentMemory) that bind return-to-pool to a using scope, AsyncSemaphoreLease concurrency primitive with timeout-bounded acquisition, ITracer/Tracer over ActivitySource, async-aware event handler extensions, process diagnostics helpers, and async ADO.NET interface shapes.</Description>
-    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/main/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NexusLabs.StronglyTypedIds.Analyzers/DiagnosticDescriptors.cs
+++ b/src/NexusLabs.StronglyTypedIds.Analyzers/DiagnosticDescriptors.cs
@@ -5,7 +5,7 @@ namespace NexusLabs.StronglyTypedIds.Analyzers;
 internal static class DiagnosticDescriptors
 {
     private const string HelpLinkBase =
-        "https://github.com/ncosentino/NexusLabs.Framework/blob/master/docs/analyzers/";
+        "https://github.com/ncosentino/NexusLabs.Framework/blob/main/docs/analyzers/";
 
     public static readonly DiagnosticDescriptor UseUuidV7CreateInsteadOfNew = new(
         id: "NLS0001",

--- a/src/NexusLabs.StronglyTypedIds/NexusLabs.StronglyTypedIds.csproj
+++ b/src/NexusLabs.StronglyTypedIds/NexusLabs.StronglyTypedIds.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Description>UUIDv7 creation support for Guid-backed strongly typed identifiers. Adds an opt-in template, TimeProvider-aware factories, dependency-injection registration, and bundled analyzer guidance without replacing generated parsing, formatting, equality, or converter behavior.</Description>
-    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/main/CHANGELOG.md</PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- The integration intentionally pins the only available 1.x generator release exactly. -->
     <NoWarn>$(NoWarn);NU5104</NoWarn>

--- a/src/NexusLabs.TUnit.Assertions.Analyzers/DiagnosticDescriptors.cs
+++ b/src/NexusLabs.TUnit.Assertions.Analyzers/DiagnosticDescriptors.cs
@@ -19,5 +19,5 @@ internal static class DiagnosticDescriptors
             "complete result. Succeeded() validates and returns the successful value; " +
             "Failed() validates and returns the captured exception.",
         helpLinkUri:
-            "https://github.com/ncosentino/NexusLabs.Framework/blob/master/docs/analyzers/NLT0001.md");
+            "https://github.com/ncosentino/NexusLabs.Framework/blob/main/docs/analyzers/NLT0001.md");
 }

--- a/src/NexusLabs.TUnit.Assertions/NexusLabs.TUnit.Assertions.csproj
+++ b/src/NexusLabs.TUnit.Assertions/NexusLabs.TUnit.Assertions.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Description>TUnit assertions for NexusLabs.Framework TriedEx and TriedNullEx results. Assert the complete result with Succeeded() or Failed(), receive the successful value or captured exception from await, and get bundled analyzer guidance for direct member assertions.</Description>
-    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/main/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NexusLabs.Testing/NexusLabs.Testing.csproj
+++ b/src/NexusLabs.Testing/NexusLabs.Testing.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Description>Framework-agnostic test helpers for Nexus Software Labs projects. Time: RegistrationObservingTimeProvider (a FakeTimeProvider that reports when the code under test arms a timer, so a test can advance the clock only after the registration it depends on has happened), a bounded AdvanceUntilAsync pump for when the expected registration count is unknown, and a Wait.UntilAsync condition wait that returns a result instead of throwing.</Description>
-    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/main/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NexusLabs.Xunit.Assertions/NexusLabs.Xunit.Assertions.csproj
+++ b/src/NexusLabs.Xunit.Assertions/NexusLabs.Xunit.Assertions.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Description>xUnit.v3 assertion helpers that integrate with the NexusLabs.Framework result-pattern types (TriedEx&lt;T&gt;, TriedNullEx&lt;T?&gt;) and HTTP response shapes. Uses C# 14 extension(Assert) blocks to augment Xunit.Assert with NexusLabs-aware overloads.</Description>
-    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/master/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>See https://github.com/ncosentino/NexusLabs.Framework/blob/main/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Step 3 of 3 in renaming the default branch. GitHub now reports `main` and branch protection has moved.

## What changed

- **Workflow filters** drop `master`; they were widened to accept both in #49 so validation never had a gap.
- **Delivery contract** `defaultBranch` -> `main`.
- **AGENTS.md** guidance, including `git config genesis.defaultBranch main`.
- **Published documentation URLs** -> `blob/main`: package `PackageReleaseNotes` and analyzer `helpLinkUri` values across 12 files. These ship inside NuGet packages, so IDE quick-info and LLM tooling follow them.
- **actionlint added** to the fail-fast validation job.

## Why actionlint

A plain YAML parse **accepts an invalid workflow**. That is exactly how a broken `run-name` reached the default branch in #46 and silently stopped the required `Review policy` check from ever reporting — PyYAML parsed the truncated scalar happily, and nothing caught it until every PR was unmergeable. actionlint is Actions-aware and rejects it precisely.

It runs in `validation-plan`, which executes on **drafts too**, so an invalid workflow now fails immediately rather than after fan-out.

The pinned `1.7.12` predates GitHub's `stacked` activity type and rejects it, while GitHub demonstrably accepts and dispatches it (`PR base`/`PR title`/`CI` all run with it). That single rule is waived with an inline reason rather than dropping a trigger the delivery contract requires. Verified locally: `exit code 0`.

## Deliberately unchanged

`docs/archived-packages/NUGET_DEPRECATION_CHECKLIST.md` keeps its `blob/master` links. It records deprecation text **already submitted to nuget.org**, which cannot be edited retroactively; rewriting it would misrepresent what was published. GitHub's rename redirect keeps those links working.

## Rename side effect worth recording

GitHub's branch rename **silently dropped the `app_id` pinning** on all three required checks (`app_id: null`). That is a security regression — any GitHub App could then satisfy a check named `CI`. I restored `app_id: 15368` on all three and verified protection on `main` is byte-identical to the pre-rename `master` baseline.

## Validation

- Build **0 warnings / 0 errors**; tests **897 total / 896 passed / 1 skipped / 0 failed**.
- `actionlint` exit `0` across all five workflows with the documented waiver.
- `genesis-delivery.json` validates against the schema; `defaultBranch` reads `main`.
- No remaining `master` reference outside the intentional one above.

## Self-assessment

| Priority | Item | Assessment |
|---|---|---|
| HIGH | Omitted behavior | None. |
| HIGH | Implementation gaps | None. |
| HIGH | Test results | 897 / 896 passed / 1 skipped / 0 failed; build 0/0; actionlint 0. |
| MEDIUM | Tech debt | The `stacked` waiver should be removed once actionlint learns the type. `stacked` itself is inert — GitHub reports no native stack membership for this repository. |
| MEDIUM | Missing coverage | Nothing asserts the shipped `helpLinkUri` URLs actually resolve; they are exercised only by humans and IDEs. |
| MEDIUM | Weak assertions | actionlint is a linter, not proof a workflow behaves correctly at run time. |
| LOW | Assumptions | GitHub's rename redirect keeps `blob/master` links alive for already-published package metadata. |