### PR TITLE
chore: add guidance layer and canonical docs map

### DIFF
--- a/.github/genesis-guidance.json
+++ b/.github/genesis-guidance.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "./genesis-guidance.schema.json",
+  "schemaVersion": 1,
+  "docs": {
+    "mapPath": "docs/README.md",
+    "pages": [
+      {
+        "path": "docs/analyzers/README.md",
+        "title": "Analyzer rules",
+        "section": "Reference",
+        "order": 1,
+        "owner": "repository"
+      },
+      {
+        "path": "docs/stacked-pull-requests.md",
+        "title": "Stacked pull requests",
+        "section": "Delivery",
+        "order": 2,
+        "owner": "repository"
+      },
+      {
+        "path": "docs/nuget-trusted-publishing-setup.md",
+        "title": "NuGet Trusted Publishing setup",
+        "section": "Delivery",
+        "order": 3,
+        "owner": "repository"
+      },
+      {
+        "path": "docs/v0.2-breaking-changes.md",
+        "title": "v0.2 breaking changes",
+        "section": "Release history",
+        "order": 4,
+        "owner": "repository"
+      },
+      {
+        "path": "docs/archived-packages/README.md",
+        "title": "Archived packages",
+        "section": "Release history",
+        "order": 5,
+        "owner": "repository"
+      }
+    ]
+  },
+  "agents": {
+    "path": "AGENTS.md",
+    "maxLines": 60,
+    "maxBytes": 3072,
+    "redirects": {
+      "claude": "CLAUDE.md",
+      "copilot": ".github/copilot-instructions.md"
+    }
+  },
+  "instructions": {
+    "managedRoot": ".github/instructions/genesis",
+    "individualReviewThreshold": {
+      "lines": 100,
+      "bytes": 8192
+    },
+    "matchedContext": {
+      "targetLines": 300,
+      "targetBytes": 16384,
+      "maxLines": 600,
+      "maxBytes": 32768
+    }
+  },
+  "review": {
+    "skillPath": ".github/skills/review-changes/SKILL.md",
+    "instructionResolver": "scripts/guidance/Get-ApplicableInstructions.ps1",
+    "validationInventory": "scripts/guidance/Get-ValidationInventory.ps1"
+  }
+}

--- a/.github/genesis-guidance.schema.json
+++ b/.github/genesis-guidance.schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ncosentino/genesis/schemas/genesis-guidance.schema.json",
+  "title": "Genesis generated guidance contract",
+  "type": "object",
+  "required": ["$schema", "schemaVersion", "agents", "instructions", "review"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "./genesis-guidance.schema.json"
+    },
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "docs": {
+      "type": "object",
+      "required": ["mapPath", "pages"],
+      "properties": {
+        "mapPath": {
+          "type": "string",
+          "pattern": "^docs/.+\\.md$"
+        },
+        "pages": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["path", "title", "section", "order", "owner"],
+            "properties": {
+              "path": {
+                "type": "string",
+                "pattern": "^docs/.+\\.md$"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1
+              },
+              "section": {
+                "type": "string",
+                "minLength": 1
+              },
+              "order": {
+                "type": "integer"
+              },
+              "owner": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "agents": {
+      "type": "object",
+      "required": ["path", "maxLines", "maxBytes", "redirects"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "const": "AGENTS.md"
+        },
+        "maxLines": {
+          "type": "integer",
+          "const": 60
+        },
+        "maxBytes": {
+          "type": "integer",
+          "const": 3072
+        },
+        "redirects": {
+          "type": "object",
+          "required": ["claude", "copilot"],
+          "properties": {
+            "claude": {
+              "type": "string",
+              "const": "CLAUDE.md"
+            },
+            "copilot": {
+              "type": "string",
+              "const": ".github/copilot-instructions.md"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "instructions": {
+      "type": "object",
+      "required": ["managedRoot", "individualReviewThreshold", "matchedContext"],
+      "properties": {
+        "managedRoot": {
+          "type": "string",
+          "const": ".github/instructions/genesis"
+        },
+        "individualReviewThreshold": {
+          "type": "object",
+          "required": ["lines", "bytes"],
+          "properties": {
+            "lines": {
+              "type": "integer",
+              "const": 100
+            },
+            "bytes": {
+              "type": "integer",
+              "const": 8192
+            }
+          },
+          "additionalProperties": false
+        },
+        "matchedContext": {
+          "type": "object",
+          "required": ["targetLines", "targetBytes", "maxLines", "maxBytes"],
+          "properties": {
+            "targetLines": {
+              "type": "integer",
+              "const": 300
+            },
+            "targetBytes": {
+              "type": "integer",
+              "const": 16384
+            },
+            "maxLines": {
+              "type": "integer",
+              "const": 600
+            },
+            "maxBytes": {
+              "type": "integer",
+              "const": 32768
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "review": {
+      "type": "object",
+      "required": ["skillPath", "instructionResolver", "validationInventory"],
+      "properties": {
+        "skillPath": {
+          "type": "string",
+          "const": ".github/skills/review-changes/SKILL.md"
+        },
+        "instructionResolver": {
+          "type": "string",
+          "const": "scripts/guidance/Get-ApplicableInstructions.ps1"
+        },
+        "validationInventory": {
+          "type": "string",
+          "const": "scripts/guidance/Get-ValidationInventory.ps1"
+        }
+      },
+      "additionalProperties": false
+    },
+    "contextExceptions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["pattern", "maxLines", "maxBytes", "phase", "owner", "reason"],
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "minLength": 1
+          },
+          "maxLines": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maxBytes": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "phase": {
+            "type": "string",
+            "const": "migration"
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/.github/skills/review-changes/SKILL.md
+++ b/.github/skills/review-changes/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: review-changes
+description: >
+  Review the current project diff before commit, push, or pull-request delivery
+  against applicable instructions, project docs and ADRs, repository-declared
+  validation, and existing CI evidence. Use for review requests, code review,
+  PR review, or delivery-readiness checks.
+---
+
+# Review project changes
+
+This skill owns review procedure, not project standards. Current instructions, docs,
+ADRs, manifests, tests, and workflows remain authoritative.
+
+## Review boundary
+
+- Judge changed lines and their direct invariant blast radius.
+- Report pre-existing divergence separately and never include it in the verdict.
+- Do not demand unrelated migration work because docs describe a target state.
+- Do not invent findings for a clean diff.
+- Review is read-only unless the user explicitly asks for fixes.
+
+## 1. Resolve the scope
+
+Confirm the worktree and branch:
+
+```powershell
+git rev-parse --show-toplevel
+git branch --show-current
+git status --short
+```
+
+Use scope in this order:
+
+1. Explicit refs, pull request, or paths supplied by the user.
+2. All uncommitted changes: unstaged, staged, and untracked.
+3. Otherwise `git merge-base origin/main HEAD` through `HEAD`.
+
+Use `git --no-pager diff`, `git --no-pager diff --cached`, and full reads for
+untracked files. For a pull request, confirm the actual base/head with `gh pr view`
+and `gh pr diff`.
+
+State the selected scope and changed files.
+
+### Resolve merge topology
+
+For coordinated pull requests, identify whether the repository uses one pull request
+with logical commits, separate default-base merge units, or a true stack. Read project
+delivery docs and `.github/genesis-delivery.json`; a feature-branch base is unsupported
+unless the executable contract declares stacks.
+
+Every stack layer is a merge unit. Request changes for a second aggregate merge pull
+request, issue-derived PR hierarchy, an unsupported base, or ready-layer behavior that
+contradicts the declared stack mode.
+
+## 2. Resolve governing sources
+
+Resolve applicable instructions:
+
+```powershell
+pwsh scripts/guidance/Get-ApplicableInstructions.ps1 -Path <changed-paths>
+```
+
+Read every returned instruction in full.
+
+If `.github/genesis-guidance.json` exists, read its declared docs map and review
+metadata. Otherwise use the README and discover existing docs/ADR indexes without
+assuming they exist. Follow relevant links from changed docs and matching
+instructions.
+
+Project-owned instructions and accepted project ADRs may specialize Genesis-managed
+defaults. Do not edit `.github/instructions/genesis/` to express a local override.
+
+## 3. Resolve validation
+
+Inventory declared validation/build surfaces:
+
+```powershell
+pwsh scripts/guidance/Get-ValidationInventory.ps1
+```
+
+Read the returned package scripts, solution/project files, language manifests,
+workflows, and Genesis delivery metadata. Inspect their actual definitions before
+choosing commands.
+
+- Run only the smallest offline command that covers the changed behavior.
+- Use package/workspace filters, project/test selectors, or equivalent repository
+  scoping when declared by the toolchain.
+- Do not invent a command that the repository does not declare or document.
+- Do not run complete suites, browser/platform matrices, hosted scenarios, or
+  credentialed/live checks on a workstation.
+- Pull request CI and declared runner profiles own complete and hosted evidence.
+- For a pull request, inspect `gh pr checks` instead of reproducing heavy work.
+
+Record every command/result and every required check that was not run.
+
+For instruction-context or guidance-budget changes, run
+`pwsh scripts/guidance/Get-InstructionContextReport.ps1` and report the full path
+distribution rather than a representative sample.
+
+## 4. Review what gates do not prove
+
+Read each changed file and inspect:
+
+- correctness, failure handling, and deterministic behavior;
+- architecture and trust-boundary compatibility;
+- manifest/schema and generated-output consequences;
+- dependency drift and unsupported version changes;
+- tests or gates missing for introduced behavior;
+- docs/instruction authority and current-truth discipline;
+- credentials, untrusted inputs, destructive actions, and privacy.
+- for public repositories, public artifacts disclose no local filesystem names/paths
+  or private-repository information in tracked files, commits, comments, or PR text.
+
+Use the current governing source for the exact rule. These categories are not a
+second standards checklist.
+
+## 5. Reflect on guidance
+
+Treat review as a bounded feedback loop, not a default instruction-edit trigger.
+
+Recommend a guidance change only when the review shows either:
+
+- one significant misstep with material risk or impact; or
+- repeated evidence of the same avoidable misstep.
+
+The lesson must be generalizable, supported by concrete evidence, and assigned to the
+correct owner. Do not propose guidance for a one-off, speculative, hyper-specific, or
+stylistic incident, or when current guidance or executable checks already cover it
+clearly and effectively. Prefer code or tests for enforceable behavior, instructions
+for recurring exact rules, docs for rationale, skills for procedures, and `AGENTS.md`
+only for safeguards needed before any file is selected.
+
+Review remains read-only. Report no guidance change when the threshold is not met; do
+not edit guidance automatically.
+
+## 6. Report
+
+Open with:
+
+- `Scope:` reviewed range or paths;
+- `Verdict:` `Approve`, `Approve with nits`, or `Request changes`;
+- `Validation:` observed/passed/failed/not-run evidence.
+- `Guidance reflection:` `no change warranted` or one concrete candidate with its
+  evidence and intended owner.
+
+Group introduced findings by severity:
+
+- **Blocker** - broken behavior, security/destructive risk, failing required
+  validation, or violation of an accepted architecture/delivery boundary.
+- **Major** - clear correctness or contract defect that should be fixed before merge.
+- **Minor** - bounded maintainability, coverage, or guidance defect.
+- **Nit** - optional polish only.
+
+Every finding includes:
+
+`severity - file:line - issue - governing source - concrete fix`
+
+If there are no introduced findings, say so plainly. State uncertainty and missing
+evidence instead of implying an unrun check passed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# Documentation
+
+Canonical map of the documentation in this repository. Every maintained page is
+reachable from here.
+
+Executable truth lives outside these pages: `.github/genesis-delivery.json`
+declares the delivery contract, `.github/instructions/` owns exact rules for
+matching edits, and the solution, projects, and workflows own build and test
+behavior. When prose and those sources disagree, the sources win.
+
+## Reference
+
+- [Analyzer rules](analyzers/README.md) — every `NLF`, `NLS`, and `NLT`
+  diagnostic shipped by the analyzer packages, with rationale and examples.
+
+## Delivery
+
+- [Stacked pull requests](stacked-pull-requests.md) — when a stack is allowed,
+  how layers are based, and the limits enforced by the `PR base` gate.
+- [NuGet Trusted Publishing setup](nuget-trusted-publishing-setup.md) — the
+  OIDC configuration used by the release workflow to publish to nuget.org.
+
+## Release history
+
+- [v0.2 breaking changes](v0.2-breaking-changes.md) — migration notes for the
+  v0.2 release.
+- [Archived packages](archived-packages/README.md) — packages that are no
+  longer published, and what replaced them.
+
+Release-by-release detail lives in [CHANGELOG.md](../CHANGELOG.md).

--- a/scripts/guidance/Get-ApplicableInstructions.ps1
+++ b/scripts/guidance/Get-ApplicableInstructions.ps1
@@ -1,0 +1,98 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Resolve project instruction files that apply to repository-relative paths.
+
+.PARAMETER Path
+    One or more repository-relative paths to resolve.
+
+.PARAMETER InstructionsRoot
+    Optional instruction root override. Defaults to <project>/.github/instructions.
+
+.OUTPUTS
+    PSCustomObject records with Path and InstructionPath.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string[]]$Path,
+
+    [string]$InstructionsRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+$projectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+. (Join-Path $PSScriptRoot 'InstructionGlob.Functions.ps1')
+if (-not $InstructionsRoot) {
+    $InstructionsRoot = Join-Path $projectRoot '.github' 'instructions'
+}
+if (-not (Test-Path $InstructionsRoot -PathType Container)) {
+    Write-Error "Instruction root not found at '$InstructionsRoot'."
+}
+$InstructionsRoot = (Resolve-Path $InstructionsRoot).Path
+
+function Test-InstructionMatch {
+    param(
+        [string]$InstructionPath,
+        [string]$RelativePath
+    )
+
+    $content = Get-Content $InstructionPath -Raw -Encoding UTF8
+    $applyToLine = $content -split "`n" |
+        ForEach-Object { $_.TrimEnd("`r") } |
+        Where-Object { $_ -match '^\s*applyTo\s*:' } |
+        Select-Object -First 1
+    if (-not $applyToLine) {
+        Write-Error "Instruction file '$InstructionPath' has no applyTo value."
+    }
+
+    $applyTo = (
+        $applyToLine -replace '^\s*applyTo\s*:\s*', ''
+    ).Trim().Trim('"', "'")
+    return Test-InstructionGlobMatch `
+        -ApplyTo $applyTo `
+        -RelativePath $RelativePath
+}
+
+$instructions = @(
+    Get-ChildItem $InstructionsRoot -Recurse -Filter '*.instructions.md' -File |
+        Sort-Object FullName
+)
+foreach ($candidate in ($Path | Sort-Object -CaseSensitive -Unique)) {
+    if ([string]::IsNullOrWhiteSpace($candidate)) {
+        Write-Error 'Repository-relative paths must not be empty.'
+    }
+    if (
+        [IO.Path]::IsPathRooted($candidate) -or
+        $candidate -match '^[A-Za-z]:[\\/]'
+    ) {
+        Write-Error "Path '$candidate' must be repository-relative."
+    }
+
+    $normalized = $candidate.Replace('\', '/')
+    while ($normalized.StartsWith('./', [StringComparison]::Ordinal)) {
+        $normalized = $normalized.Substring(2)
+    }
+    $normalized = $normalized.TrimStart('/')
+    if (
+        [string]::IsNullOrWhiteSpace($normalized) -or
+        $normalized -eq '.' -or
+        $normalized.Split('/') -contains '..'
+    ) {
+        Write-Error "Path '$candidate' must identify a file inside the repository."
+    }
+
+    foreach ($instruction in $instructions) {
+        if (Test-InstructionMatch $instruction.FullName $normalized) {
+            [PSCustomObject]@{
+                Path            = $normalized
+                InstructionPath = [IO.Path]::GetRelativePath(
+                    $projectRoot,
+                    $instruction.FullName
+                ).Replace('\', '/')
+            }
+        }
+    }
+}

--- a/scripts/guidance/Get-InstructionContextReport.ps1
+++ b/scripts/guidance/Get-InstructionContextReport.ps1
@@ -1,0 +1,310 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Measures the complete matched instruction context for repository files.
+
+.DESCRIPTION
+    Resolves every instruction once, scans explicit paths or every tracked/untracked
+    non-ignored file, and reports target and hard-budget violations. This command is
+    read-only. UTF-8 byte counts normalize line endings to LF so checkout settings do
+    not change the reported instruction context.
+
+.PARAMETER ProjectRoot
+    Repository root. Defaults to the project containing this script.
+
+.PARAMETER InstructionsRoot
+    Instruction root. Defaults to <ProjectRoot>/.github/instructions.
+
+.PARAMETER Path
+    Optional repository-relative paths. When omitted, Git supplies every tracked and
+    untracked non-ignored path.
+
+.PARAMETER TargetLines
+    Target matched-context line budget.
+
+.PARAMETER TargetBytes
+    Target matched-context UTF-8 byte budget after line-ending normalization.
+
+.PARAMETER MaxLines
+    Hard matched-context line ceiling.
+
+.PARAMETER MaxBytes
+    Hard matched-context UTF-8 byte ceiling after line-ending normalization.
+
+.PARAMETER Json
+    Emit JSON.
+#>
+[CmdletBinding()]
+param(
+    [string]$ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path,
+    [string]$InstructionsRoot,
+    [string[]]$Path = @(),
+    [ValidateRange(1, [int]::MaxValue)]
+    [int]$TargetLines = 300,
+    [ValidateRange(1, [int]::MaxValue)]
+    [int]$TargetBytes = 16384,
+    [ValidateRange(1, [int]::MaxValue)]
+    [int]$MaxLines = 600,
+    [ValidateRange(1, [int]::MaxValue)]
+    [int]$MaxBytes = 32768,
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ProjectRoot = (Resolve-Path -LiteralPath $ProjectRoot).Path
+$InstructionsRoot =
+    if ([string]::IsNullOrWhiteSpace($InstructionsRoot)) {
+        Join-Path $ProjectRoot '.github' 'instructions'
+    } else {
+        (Resolve-Path -LiteralPath $InstructionsRoot).Path
+    }
+if (-not (Test-Path -LiteralPath $InstructionsRoot -PathType Container)) {
+    throw "Instruction root not found: '$InstructionsRoot'."
+}
+
+. (Join-Path $PSScriptRoot 'InstructionGlob.Functions.ps1')
+
+$contextExceptions = @()
+$guidanceContractPath = Join-Path (
+    $ProjectRoot) '.github' 'genesis-guidance.json'
+if (Test-Path -LiteralPath $guidanceContractPath -PathType Leaf) {
+    $guidanceContract = Get-Content `
+        -LiteralPath $guidanceContractPath `
+        -Raw `
+        -Encoding UTF8 |
+        ConvertFrom-Json
+    $matchedContext = $guidanceContract.instructions.matchedContext
+    if (-not $PSBoundParameters.ContainsKey('TargetLines')) {
+        $TargetLines = [int]$matchedContext.targetLines
+    }
+    if (-not $PSBoundParameters.ContainsKey('TargetBytes')) {
+        $TargetBytes = [int]$matchedContext.targetBytes
+    }
+    if (-not $PSBoundParameters.ContainsKey('MaxLines')) {
+        $MaxLines = [int]$matchedContext.maxLines
+    }
+    if (-not $PSBoundParameters.ContainsKey('MaxBytes')) {
+        $MaxBytes = [int]$matchedContext.maxBytes
+    }
+    $contextExceptions = @($guidanceContract.contextExceptions)
+}
+if ($TargetLines -gt $MaxLines -or $TargetBytes -gt $MaxBytes) {
+    throw 'Target instruction budgets cannot exceed hard ceilings.'
+}
+
+function Get-FrontmatterValue {
+    param(
+        [Parameter(Mandatory)][string]$Content,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    $match = [regex]::Match(
+        $Content,
+        "(?m)^\s*$([regex]::Escape($Name))\s*:\s*(.+?)\s*$")
+    if (-not $match.Success) {
+        return ''
+    }
+    return $match.Groups[1].Value.Trim().Trim('"', "'")
+}
+
+function ConvertTo-RepositoryPath {
+    param([Parameter(Mandatory)][string]$Value)
+
+    if ([IO.Path]::IsPathRooted($Value) -or $Value -match '^[A-Za-z]:[\\/]') {
+        throw "Path '$Value' must be repository-relative."
+    }
+    $normalized = $Value.Replace('\', '/').TrimStart('/')
+    while ($normalized.StartsWith('./', [StringComparison]::Ordinal)) {
+        $normalized = $normalized.Substring(2)
+    }
+    if (
+        [string]::IsNullOrWhiteSpace($normalized) -or
+        $normalized -eq '.' -or
+        $normalized.Split('/') -contains '..'
+    ) {
+        throw "Path '$Value' must identify a file inside the repository."
+    }
+    return $normalized
+}
+
+if ($Path.Count -eq 0) {
+    $paths = @(& git -C $ProjectRoot ls-files --cached --others --exclude-standard)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to enumerate repository files in '$ProjectRoot'."
+    }
+} else {
+    $paths = @($Path)
+}
+$paths = @(
+    $paths |
+        ForEach-Object { ConvertTo-RepositoryPath -Value ([string]$_) } |
+        Sort-Object -CaseSensitive -Unique
+)
+
+$instructions = @(
+    Get-ChildItem -LiteralPath $InstructionsRoot -Recurse -Filter '*.instructions.md' -File |
+        Sort-Object FullName |
+        ForEach-Object {
+            $content = Get-Content -LiteralPath $_.FullName -Raw -Encoding UTF8
+            $canonicalContent = $content.Replace("`r`n", "`n").Replace("`r", "`n")
+            $applyTo = Get-FrontmatterValue -Content $content -Name 'applyTo'
+            if ([string]::IsNullOrWhiteSpace($applyTo)) {
+                throw "Instruction '$($_.FullName)' has no applyTo value."
+            }
+            $regexes = @(
+                foreach ($pattern in @(Split-InstructionGlobPatterns -ApplyTo $applyTo)) {
+                    foreach ($expanded in @(Expand-InstructionGlobPattern -Pattern $pattern)) {
+                        [regex]::new(
+                            (ConvertTo-InstructionGlobRegex -Pattern $expanded),
+                            [Text.RegularExpressions.RegexOptions]::CultureInvariant)
+                    }
+                }
+            )
+            $relative = [IO.Path]::GetRelativePath(
+                $InstructionsRoot,
+                $_.FullName
+            ).Replace('\', '/')
+            [PSCustomObject]@{
+                path = $relative
+                apply_to = $applyTo
+                lines = @(Get-Content -LiteralPath $_.FullName -Encoding UTF8).Count
+                bytes = [Text.Encoding]::UTF8.GetByteCount($canonicalContent)
+                managed = $relative.StartsWith(
+                    'genesis/',
+                    [StringComparison]::Ordinal)
+                regexes = $regexes
+                match_count = 0
+            }
+        }
+)
+
+$contexts = [System.Collections.Generic.List[object]]::new()
+foreach ($relativePath in $paths) {
+    $lines = 0
+    $bytes = 0
+    $managedLines = 0
+    $managedBytes = 0
+    $matched = [System.Collections.Generic.List[string]]::new()
+    foreach ($instruction in $instructions) {
+        $isMatch = $false
+        foreach ($regex in $instruction.regexes) {
+            if ($regex.IsMatch($relativePath)) {
+                $isMatch = $true
+                break
+            }
+        }
+        if (-not $isMatch) {
+            continue
+        }
+        $lines += [int]$instruction.lines
+        $bytes += [int]$instruction.bytes
+        if ($instruction.managed) {
+            $managedLines += [int]$instruction.lines
+            $managedBytes += [int]$instruction.bytes
+        }
+        $instruction.match_count++
+        $matched.Add([string]$instruction.path) | Out-Null
+    }
+    $exception = @(
+        $contextExceptions |
+            Where-Object {
+                Test-InstructionGlobMatch `
+                    -ApplyTo ([string]$_.pattern) `
+                    -RelativePath $relativePath
+            } |
+            Select-Object -First 1
+    )
+    $limitLines =
+        if ($exception.Count) { [int]$exception[0].maxLines }
+        else { $MaxLines }
+    $limitBytes =
+        if ($exception.Count) { [int]$exception[0].maxBytes }
+        else { $MaxBytes }
+    $contexts.Add([PSCustomObject][ordered]@{
+        path = $relativePath
+        lines = $lines
+        bytes = $bytes
+        managed_lines = $managedLines
+        managed_bytes = $managedBytes
+        target_exceeded = ($lines -gt $TargetLines -or $bytes -gt $TargetBytes)
+        hard_exceeded = ($lines -gt $limitLines -or $bytes -gt $limitBytes)
+        managed_hard_exceeded = (
+            $managedLines -gt $limitLines -or
+            $managedBytes -gt $limitBytes)
+        limit_lines = $limitLines
+        limit_bytes = $limitBytes
+        exception =
+            if ($exception.Count) {
+                [PSCustomObject][ordered]@{
+                    pattern = [string]$exception[0].pattern
+                    owner = [string]$exception[0].owner
+                    reason = [string]$exception[0].reason
+                }
+            } else {
+                $null
+            }
+        matched = @($matched)
+    }) | Out-Null
+}
+
+$targetExceeded = @($contexts | Where-Object target_exceeded)
+$hardExceeded = @($contexts | Where-Object hard_exceeded)
+$managedHardExceeded = @($contexts | Where-Object managed_hard_exceeded)
+$top = @(
+    $contexts |
+        Sort-Object `
+            @{ Expression = { $_.lines }; Descending = $true }, `
+            @{ Expression = { $_.bytes }; Descending = $true }, `
+            @{ Expression = { $_.path }; Descending = $false } |
+        Select-Object -First 25
+)
+$topInstructions = @(
+    $instructions |
+        ForEach-Object {
+            [PSCustomObject][ordered]@{
+                path = [string]$_.path
+                apply_to = [string]$_.apply_to
+                lines = [int]$_.lines
+                bytes = [int]$_.bytes
+                match_count = [int]$_.match_count
+                weighted_lines = [int]$_.lines * [int]$_.match_count
+                weighted_bytes = [int]$_.bytes * [int]$_.match_count
+            }
+        } |
+        Sort-Object `
+            @{ Expression = { $_.weighted_lines }; Descending = $true }, `
+            @{ Expression = { $_.path }; Descending = $false } |
+        Select-Object -First 25
+)
+$report = [PSCustomObject][ordered]@{
+    schema_version = '1'
+    status =
+        if ($hardExceeded.Count -gt 0) { 'hard-limit-exceeded' }
+        elseif ($targetExceeded.Count -gt 0) { 'target-exceeded' }
+        else { 'clean' }
+    budgets = [ordered]@{
+        target_lines = $TargetLines
+        target_bytes = $TargetBytes
+        max_lines = $MaxLines
+        max_bytes = $MaxBytes
+    }
+    summary = [ordered]@{
+        instruction_count = $instructions.Count
+        path_count = $contexts.Count
+        target_exceeded = $targetExceeded.Count
+        hard_exceeded = $hardExceeded.Count
+        managed_hard_exceeded = $managedHardExceeded.Count
+        max_lines = ($contexts | Measure-Object lines -Maximum).Maximum
+        max_bytes = ($contexts | Measure-Object bytes -Maximum).Maximum
+    }
+    top_contexts = $top
+    top_instructions = $topInstructions
+    contexts = @($contexts)
+}
+
+if ($Json) {
+    $report | ConvertTo-Json -Depth 12
+} else {
+    $report
+}

--- a/scripts/guidance/Get-ValidationInventory.ps1
+++ b/scripts/guidance/Get-ValidationInventory.ps1
@@ -1,0 +1,164 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Inventory repository-declared validation and build surfaces.
+
+.PARAMETER ProjectRoot
+    Repository root to inspect. Defaults to the project containing this script.
+
+.PARAMETER Json
+    Emit JSON instead of a PSCustomObject.
+
+.OUTPUTS
+    A deterministic inventory of package scripts, .NET files, language manifests,
+    workflows, and Genesis delivery metadata.
+#>
+[CmdletBinding()]
+param(
+    [string]$ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path,
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'Stop'
+$ProjectRoot = (Resolve-Path $ProjectRoot).Path
+
+function Get-RelativePath {
+    param([string]$Path)
+    return [IO.Path]::GetRelativePath($ProjectRoot, $Path).Replace('\', '/')
+}
+
+function Get-ProjectFiles {
+    $excludedDirectories = [Collections.Generic.HashSet[string]]::new(
+        [StringComparer]::OrdinalIgnoreCase)
+    foreach ($name in @(
+        '.git',
+        '.next',
+        '.nuxt',
+        '.output',
+        'bin',
+        'build',
+        'coverage',
+        'dist',
+        'node_modules',
+        'obj',
+        'site',
+        'target'
+    )) {
+        [void]$excludedDirectories.Add($name)
+    }
+
+    $pending = [Collections.Generic.Stack[string]]::new()
+    $pending.Push($ProjectRoot)
+    while ($pending.Count -gt 0) {
+        $directory = $pending.Pop()
+        foreach ($item in (Get-ChildItem $directory -Force)) {
+            if ($item.PSIsContainer) {
+                if (
+                    -not $excludedDirectories.Contains($item.Name) -and
+                    -not ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)
+                ) {
+                    $pending.Push($item.FullName)
+                }
+            } else {
+                $item
+            }
+        }
+    }
+}
+
+$projectFiles = @(Get-ProjectFiles)
+$packageManifests = @(
+    $projectFiles |
+        Where-Object Name -CEQ 'package.json' |
+        Sort-Object FullName |
+        ForEach-Object {
+            $manifest = Get-Content $_.FullName -Raw -Encoding UTF8 | ConvertFrom-Json
+            $scripts = [ordered]@{}
+            if ($manifest.PSObject.Properties['scripts']) {
+                foreach ($script in @($manifest.scripts.PSObject.Properties | Sort-Object Name)) {
+                    $scripts[$script.Name] = [string]$script.Value
+                }
+            }
+            [PSCustomObject]@{
+                path    = Get-RelativePath $_.FullName
+                scripts = $scripts
+            }
+        }
+)
+
+$dotnetSolutions = @(
+    $projectFiles |
+        Where-Object {
+            $_.Extension -in @('.sln', '.slnx')
+        } |
+        Sort-Object FullName |
+        ForEach-Object { Get-RelativePath $_.FullName }
+)
+$dotnetProjects = @(
+    $projectFiles |
+        Where-Object Extension -CEQ '.csproj' |
+        Sort-Object FullName |
+        ForEach-Object { Get-RelativePath $_.FullName }
+)
+
+$manifestKinds = [ordered]@{
+    'go.mod'       = 'go'
+    'Cargo.toml'   = 'rust'
+    'pubspec.yaml' = 'dart-flutter'
+    'hugo.toml'    = 'hugo'
+    'pyproject.toml' = 'python'
+    'Makefile'     = 'make'
+}
+$languageManifests = @(
+    foreach ($entry in $manifestKinds.GetEnumerator()) {
+        $projectFiles |
+            Where-Object Name -CEQ $entry.Key |
+            ForEach-Object {
+                [PSCustomObject]@{
+                    path = Get-RelativePath $_.FullName
+                    kind = $entry.Value
+                }
+            }
+    }
+) | Sort-Object path, kind
+
+$workflowRoot = Join-Path $ProjectRoot '.github' 'workflows'
+$workflows = @(
+    if (Test-Path $workflowRoot -PathType Container) {
+        Get-ChildItem $workflowRoot -File |
+            Where-Object Extension -in @('.yml', '.yaml') |
+            Sort-Object Name |
+            ForEach-Object {
+                $content = Get-Content $_.FullName -Raw -Encoding UTF8
+                $name = [regex]::Match($content, '(?m)^name:\s*(.+?)\s*$')
+                [PSCustomObject]@{
+                    path = Get-RelativePath $_.FullName
+                    name = if ($name.Success) { $name.Groups[1].Value.Trim("'`"") } else { $_.BaseName }
+                }
+            }
+    }
+)
+
+$deliveryPath = Join-Path $ProjectRoot '.github' 'genesis-delivery.json'
+$delivery =
+    if (Test-Path $deliveryPath -PathType Leaf) {
+        Get-Content $deliveryPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    } else {
+        $null
+    }
+
+$inventory = [PSCustomObject]@{
+    projectRoot       = $ProjectRoot
+    packageManifests  = $packageManifests
+    dotnetSolutions   = $dotnetSolutions
+    dotnetProjects    = $dotnetProjects
+    languageManifests = $languageManifests
+    workflows         = $workflows
+    delivery          = $delivery
+}
+
+if ($Json) {
+    $inventory | ConvertTo-Json -Depth 12
+} else {
+    $inventory
+}

--- a/scripts/guidance/InstructionGlob.Functions.ps1
+++ b/scripts/guidance/InstructionGlob.Functions.ps1
@@ -1,0 +1,138 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Shared instruction applyTo glob parsing and matching functions.
+
+.DESCRIPTION
+    Supports comma-separated patterns, brace alternatives, *, **, and ? while keeping
+    commas inside brace groups intact.
+#>
+
+function Split-InstructionGlobPatterns {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ApplyTo
+    )
+
+    $patterns = [System.Collections.Generic.List[string]]::new()
+    $current = [Text.StringBuilder]::new()
+    $braceDepth = 0
+    foreach ($character in $ApplyTo.ToCharArray()) {
+        if ($character -ceq '{') {
+            $braceDepth++
+        } elseif ($character -ceq '}') {
+            $braceDepth--
+            if ($braceDepth -lt 0) {
+                throw "Invalid instruction glob '$ApplyTo': unmatched closing brace."
+            }
+        }
+
+        if ($character -ceq ',' -and $braceDepth -eq 0) {
+            $pattern = $current.ToString().Trim()
+            if ($pattern) {
+                $patterns.Add($pattern)
+            }
+            [void]$current.Clear()
+        } else {
+            [void]$current.Append($character)
+        }
+    }
+    if ($braceDepth -ne 0) {
+        throw "Invalid instruction glob '$ApplyTo': unmatched opening brace."
+    }
+    $lastPattern = $current.ToString().Trim()
+    if ($lastPattern) {
+        $patterns.Add($lastPattern)
+    }
+    return @($patterns)
+}
+
+function Expand-InstructionGlobPattern {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Pattern
+    )
+
+    $openIndex = $Pattern.IndexOf('{')
+    if ($openIndex -lt 0) {
+        return @($Pattern)
+    }
+
+    $depth = 0
+    $closeIndex = -1
+    for ($index = $openIndex; $index -lt $Pattern.Length; $index++) {
+        if ($Pattern[$index] -ceq '{') {
+            $depth++
+        } elseif ($Pattern[$index] -ceq '}') {
+            $depth--
+            if ($depth -eq 0) {
+                $closeIndex = $index
+                break
+            }
+        }
+    }
+    if ($closeIndex -lt 0) {
+        throw "Invalid instruction glob '$Pattern': unmatched opening brace."
+    }
+
+    $prefix = $Pattern.Substring(0, $openIndex)
+    $body = $Pattern.Substring($openIndex + 1, $closeIndex - $openIndex - 1)
+    $suffix = $Pattern.Substring($closeIndex + 1)
+    $alternatives = Split-InstructionGlobPatterns -ApplyTo $body
+    if ($alternatives.Count -eq 0) {
+        throw "Invalid instruction glob '$Pattern': empty brace alternatives."
+    }
+
+    $expanded = [System.Collections.Generic.List[string]]::new()
+    foreach ($alternative in $alternatives) {
+        foreach ($value in @(
+            Expand-InstructionGlobPattern `
+                -Pattern ($prefix + $alternative + $suffix)
+        )) {
+            $expanded.Add($value)
+        }
+    }
+    return @($expanded)
+}
+
+function ConvertTo-InstructionGlobRegex {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Pattern
+    )
+
+    $regex = [regex]::Escape($Pattern)
+    $regex = $regex -replace '\\\*\\\*/', '(?:.*/)?'
+    $regex = $regex -replace '\\\*\\\*', '.*'
+    $regex = $regex -replace '\\\*', '[^/]*'
+    $regex = $regex -replace '\\\?', '[^/]'
+    return "^$regex$"
+}
+
+function Test-InstructionGlobMatch {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ApplyTo,
+
+        [Parameter(Mandatory)]
+        [string]$RelativePath
+    )
+
+    $normalized = $RelativePath.Replace('\', '/')
+    foreach ($pattern in @(
+        Split-InstructionGlobPatterns -ApplyTo $ApplyTo
+    )) {
+        foreach ($expanded in @(
+            Expand-InstructionGlobPattern -Pattern $pattern
+        )) {
+            if ($normalized -cmatch (ConvertTo-InstructionGlobRegex -Pattern $expanded)) {
+                return $true
+            }
+        }
+    }
+    return $false
+}

--- a/scripts/guidance/Resolve-ValidationScope.ps1
+++ b/scripts/guidance/Resolve-ValidationScope.ps1
@@ -1,0 +1,99 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Resolve generated-project CI scope for one workflow event.
+
+.PARAMETER EventName
+    Caller event name: pull_request, push, or workflow_dispatch.
+
+.PARAMETER RequestedScope
+    workflow_dispatch scope: full or subset.
+
+.PARAMETER IsDraft
+    Whether the pull request is draft.
+
+.PARAMETER DraftMode
+    Existing project draft mode: full, subset, or ready-only.
+
+.PARAMETER ChangedFiles
+    Complete pull-request changed-file paths, including previous rename paths.
+
+.PARAMETER Conservative
+    Disable guidance-only classification when file discovery is incomplete.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('pull_request','push','workflow_dispatch')]
+    [string]$EventName,
+
+    [string]$RequestedScope = '',
+    [bool]$IsDraft = $false,
+
+    [ValidateSet('full','subset','ready-only')]
+    [string]$DraftMode = 'ready-only',
+
+    [string[]]$ChangedFiles = @(),
+    [switch]$Conservative
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($EventName -eq 'workflow_dispatch') {
+    $scope = if ($RequestedScope) { $RequestedScope } else { 'full' }
+    if ($scope -notin @('full','subset')) {
+        Write-Error "Unsupported requested validation scope '$scope'."
+    }
+    if ($scope -eq 'subset') {
+        return 'full'
+    }
+    return $scope
+}
+if ($EventName -eq 'push') {
+    return 'full'
+}
+
+$normalizedFiles = @(
+    foreach ($changedFile in $ChangedFiles) {
+        $normalized = ([string]$changedFile).Replace('\','/')
+        while ($normalized.StartsWith('./',[StringComparison]::Ordinal)) {
+            $normalized = $normalized.Substring(2)
+        }
+        $normalized = $normalized.TrimStart('/')
+        if ($normalized) { $normalized }
+    }
+) | Sort-Object -CaseSensitive -Unique
+
+$guidancePatterns = @(
+    '^AGENTS\.md$',
+    '^CLAUDE\.md$',
+    '^README\.md$',
+    '^\.github/copilot-instructions\.md$',
+    '^\.github/genesis-guidance(?:\.schema)?\.json$',
+    '^\.github/instructions/',
+    '^\.github/skills/',
+    '^docs/',
+    '^scripts/guidance/'
+)
+$guidanceOnly = (
+    -not $Conservative -and
+    $normalizedFiles.Count -gt 0 -and
+    @(
+        $normalizedFiles |
+            Where-Object {
+                $path = $_
+                -not ($guidancePatterns | Where-Object { $path -match $_ })
+            }
+    ).Count -eq 0
+)
+if ($guidanceOnly) {
+    return 'guidance'
+}
+
+if ($IsDraft) {
+    if ($DraftMode -eq 'subset') {
+        return 'full'
+    }
+    return $DraftMode
+}
+return 'full'


### PR DESCRIPTION
## What

Adds the guidance surfaces this repository was missing. **Purely additive** — no
existing file is modified (9 files, all `A`).

| File | Purpose |
| --- | --- |
| `.github/skills/review-changes/SKILL.md` | Repository-local review procedure |
| `scripts/guidance/` (5 scripts) | Instruction resolver, validation inventory, context report, scope resolver |
| `.github/genesis-guidance.json` + schema | Declares docs map, root budgets, managed instruction root, review wiring |
| `docs/README.md` | Canonical documentation map |

## Why

The review procedure and instruction resolution had no in-repo entry point, so
no repository-local self-review could run before delivery. The guidance
inventory flagged both a missing review skill and an undiscoverable docs map.

## Design notes

- **The review skill is kept byte-identical to upstream on purpose.** It derives
  the diff, applicable instructions, docs map, and validation surfaces from the
  contract and inventory. Baking repository commands into it would give it a
  second standards corpus, which its own boundary forbids. Every reference it
  makes resolves here: `origin/main`, both resolver scripts, and the contract.
- `docs/README.md` **indexes** the existing analyzer and archived-package
  indexes rather than flattening all 43 pages, preserving the current hierarchy.

## Validation

- `Test-Json -SchemaFile` on `.github/genesis-guidance.json` → **True**.
- All **6** relative links in `docs/README.md` resolve.
- All **5** pages declared in the contract exist.
- Both resolvers execute against this repository from their new location and
  return clean repository-relative paths — `Get-ValidationInventory.ps1`
  discovers 22 projects, 5 workflows, and the delivery contract.
- Guidance inventory re-run: the *missing review skill* and *no docs map* flags
  are both gone.

## Scope boundaries (deliberately not fixed here)

These remain open and are addressed in follow-up PRs, so this one stays additive
and independently reviewable:

- `AGENTS.md` is **131 lines / 7,127 bytes** against a 60-line / 3,072-byte
  budget.
- Matched instruction context for a C# test file is **791 lines / 36.5 KiB**,
  past the hard 600-line / 32-KiB ceiling.

Both are pre-existing and unrelated to these additions.
