### PR TITLE
ci: give Dependabot conventional commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # The `PR title` gate requires conventional-commit titles, and Dependabot
+    # derives the title from this prefix. `include: scope` appends the
+    # dependency type, so `chore` becomes `chore(deps): ...`. Do not put the
+    # scope in `prefix` as well or it is emitted twice.
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     groups:
       dotnet-dependencies:
         patterns:
@@ -15,3 +22,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
## What

Gives Dependabot conventional-commit prefixes so its pull requests stop opening
with a failing required check.

```yaml
commit-message:
  prefix: "chore"   # nuget          -> chore(deps): ...
  include: "scope"
commit-message:
  prefix: "ci"      # github-actions -> ci(deps): ...
  include: "scope"
```

## Why

The `PR title` gate requires conventional-commit titles, but the config
declared no `commit-message` prefix. Every Dependabot pull request therefore
opened already failing a required check and needed a manual retitle before it
could merge. **#56 failed exactly this way** and had to be retitled by hand to
land.

## Validation

Checked the generated titles against the required pattern in
`.github/genesis-delivery.json`:

| Title | Result |
| --- | --- |
| `chore(deps): bump the dotnet-dependencies group with 17 updates` | **PASS** |
| `ci(deps): bump actions/checkout from 7 to 8` | **PASS** |
| `Bump the dotnet-dependencies group with 17 updates` (current behavior) | **FAIL** |

YAML parses; both ecosystems resolve with prefixes `chore` and `ci`.

## Two deliberate omissions, from the GitHub reference

- **The scope is not in `prefix`.** The docs state `include: scope` follows *any*
  prefix with the dependency type, so `prefix: "chore(deps)"` combined with
  `include: scope` would emit `chore(deps)(deps)`.
- **`prefix-development` is omitted** — the docs list it as supported for
  `bundler`, `composer`, `mix`, `maven`, `npm`, `pip`, and `uv`. NuGet is not
  among them.

Source: <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#commit-message->

## Disclosed uncertainty

The same reference notes that for **grouped** updates the branch name and pull
request title are defined by the group identifier. I read that as the group name
appearing *within* the generated title rather than the prefix being bypassed,
and the observed title (`Bump the dotnet-dependencies group with 17 updates`) is
consistent with a default prefix being absent rather than suppressed. I could
not prove it without waiting for the next scheduled run. If the next Dependabot
pull request still opens with a non-conventional title, the fallback is to keep
retitling, or to relax the gate for that author.
